### PR TITLE
Add Startpage as a search engine option

### DIFF
--- a/browser/Reynard/Client/Preferences/BrowserPreferences.swift
+++ b/browser/Reynard/Client/Preferences/BrowserPreferences.swift
@@ -16,6 +16,7 @@ final class BrowserPreferences {
         case brave
         case duckDuckGo
         case ecosia
+        case startpage
         case custom
         
         var displayName: String {
@@ -32,6 +33,8 @@ final class BrowserPreferences {
                 return "DuckDuckGo"
             case .ecosia:
                 return "Ecosia"
+            case .startpage:
+                return "Startpage"
             case .custom:
                 return "Custom"
             }
@@ -51,6 +54,8 @@ final class BrowserPreferences {
                 return "https://duckduckgo.com/?q=%s"
             case .ecosia:
                 return "https://www.ecosia.org/search?q=%s"
+            case .startpage:
+                return "https://www.startpage.com/sp/search?query=%s"
             case .custom:
                 return nil
             }


### PR DESCRIPTION
Adds Startpage to the built-in search engine options in BrowserPreferences, alongside the existing engines.

Startpage has a built-in proxy mode, which is useful on older iOS versions where VPN options are limited so that's what made it worth adding for my use case.

Tested on a physical device, selecting Startpage and searching works as expected.