### PR TITLE
Add Page Zoom, keyboard-safe UX, accents, and resume recovery

### DIFF
--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -475,6 +475,34 @@ Implementation plan:
 - Update `AppearancePreferencesViewController` to show preset rows plus a Custom row, present the system color picker where available, present a hex entry alert, and reload immediately after custom changes.
 - Keep this native-only and validate with the archive-only workflow using Gecko checkpoint run `28038685786`.
 
+Implementation outcome:
+
+- Custom accent app-code commit: `e3c2624e4b9628e2f042aebd8adeb22012779a31` (`feat(app): add custom accent colors`).
+- Files changed:
+  - `browser/Reynard/Client/Interface/Appearance/BrowserAppearance.swift`
+  - `browser/Reynard/Client/Preferences/BrowserPreferences.swift`
+  - `browser/Reynard/Client/Interface/Library/Settings/Sections/General/Appearance/AppearancePreferencesViewController.swift`
+- Local validation:
+  - `git diff --check` passed.
+  - `bash -n tools/development/build-gecko.sh` passed.
+  - `bash -n tools/release/build-app.sh` passed.
+  - `bash -n browser/Scripts/AddGecko.sh` passed.
+- Archive-only workflow run: `28080748345`, `https://github.com/lowestprime/reynard-browser/actions/runs/28080748345`.
+- Run result: success in `7m37s`.
+- Reused Gecko checkpoint: `gecko-dist-aarch64-apple-ios` from run `28038685786`; no full Gecko rebuild was triggered.
+- Uploaded artifact: `Reynard-latest-main-ipa`.
+- Local downloaded IPA: `C:\Users\Cooper\Downloads\Reynard-latest-main-28080748345\Reynard.ipa`.
+- Local IPA size: `109652723` bytes.
+- Local IPA SHA-256: `c53caab3fe6d857b7c9a0328d70290b0df2e35f707ec869505853cbe82dcae46`.
+- `unzip -tq` passed with no compressed-data errors.
+- ZIP/plist/Mach-O inspection found `3032` entries, `0` duplicate paths, required app/extensions/GeckoView entries, `CFBundleVersion` `e3c2624` for the main app and extensions, and arm64 Mach-O headers.
+- Marker scan found `Custom`, `Custom Accent`, `Custom Accent Hex`, `Choose Custom Color`, `#RRGGBB`, `Invalid Accent Color`, all preset accent names, `customAccent`, `AppearanceSettings`, `OLED Black`, and `Page Zoom`.
+- New fork prerelease: `https://github.com/lowestprime/reynard-browser/releases/tag/reynard-custom-accent-color-2026-06-24`.
+- Release assets:
+  - `Reynard.ipa`, size `109652723`, digest `sha256:c53caab3fe6d857b7c9a0328d70290b0df2e35f707ec869505853cbe82dcae46`.
+  - `Reynard.ipa.sha256`, size `77`, digest `sha256:bdb475a409e2dfdbdba2e6feafb7c6594eb57d5d07255f6fc03cb55a20b495f8`.
+- Remaining manual validation: install the IPA on iPhone and check Appearance > Accent presets plus Custom, picker, hex entry, persistence, theme coverage, Page Zoom, and the keyboard fix.
+
 ## Plan of Work
 
 First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -8,7 +8,7 @@ Produce a verified latest-main Reynard IPA from the `lowestprime/reynard-browser
 
 ## Success Criteria
 
-- [ ] The fork is synchronized with or verified against latest upstream `minh-ton/reynard-browser@main`.
+- [x] The fork is synchronized with or verified against latest upstream `minh-ton/reynard-browser@main`.
 - [ ] GitHub Actions workflow `Build Latest Reynard IPA` completes successfully on `main`.
 - [ ] Artifact `Reynard-latest-main-ipa` is uploaded and downloaded locally.
 - [ ] Downloaded artifact contains `Reynard.ipa`.
@@ -73,6 +73,8 @@ Latest inspected workflow failure:
 - [x] Workflow rerun started.
 - [x] Workflow rerun completed with a new WASI runtime failure.
 - [x] Second targeted WASI runtime patch applied.
+- [x] Non-final run confirmed dependencies passed and reached `Build Gecko`.
+- [x] Latest upstream `minh-ton/reynard-browser@main` merged.
 - [ ] IPA artifact downloaded and inspected.
 - [ ] Page Zoom architecture inspected.
 - [ ] Page Zoom implemented.
@@ -85,6 +87,9 @@ Latest inspected workflow failure:
 - Homebrew LLVM 22.1.7 on `macos-26` no longer provides `wasm-ld` under `/opt/homebrew/opt/llvm/bin`; Homebrew prints that LLD is a separate formula.
 - Run `27993600431` proved the explicit `lld` patch worked: `command -v wasm-ld` returned `/opt/homebrew/opt/lld/bin/wasm-ld` and `wasm-ld --version` returned `Homebrew LLD 22.1.7`.
 - The same run exposed the next WASI runtime dependency: `/opt/homebrew/opt/llvm/bin/clang --target=wasm32-unknown-wasi --sysroot=/opt/homebrew/share/wasi-sysroot /tmp/wasm-test.c -o /tmp/wasm-test.wasm` failed with `cannot open ... lib/wasm32-unknown-wasi/libclang_rt.builtins.a: No such file or directory`.
+- Run `27993866717` passed `Install build dependencies`, `Update Gecko source`, `Apply Gecko patches`, `Build idevice FFI`, and `Force Gecko to use Xcode ld64`; it reached `Build Gecko` before being intentionally canceled because the fork had not yet merged latest upstream main.
+- After `git fetch upstream main`, `upstream/main...HEAD` was `9 13`, proving the fork was missing nine upstream commits. The upstream head was `0fcee2c40f8629c50a9481419dfb9184c75c0236` (`Hide tab bar when in iPad 1/3 split screen`).
+- `git merge upstream/main --no-edit` completed without conflicts and produced merge commit `6190269606d3c09e97b70db08a9f85ecaf1d861e`; `git merge-base --is-ancestor upstream/main HEAD` then confirmed upstream is contained in the fork.
 
 ## Decision Log
 
@@ -96,6 +101,10 @@ Latest inspected workflow failure:
   - Reason: The next failed log shows `wasm-ld` is now available but clang lacks WASI Compiler-RT builtins. Homebrew describes `wasi-runtimes` as the Compiler-RT and libc++ runtimes for WASI.
   - Evidence: Run `27993600431`, `Install build dependencies`, `wasm-ld --version` succeeded, then clang failed opening `libclang_rt.builtins.a`.
   - Consequence: The next run is the one further targeted WASI repair allowed before falling back to `--without-wasm-sandboxed-libraries` if WASI still fails.
+- Decision: Cancel run `27993866717` and merge upstream before continuing.
+  - Reason: A successful artifact from that run would not have satisfied the latest-main requirement because upstream/main was not contained in the fork.
+  - Evidence: `git rev-list --left-right --count upstream/main...HEAD` returned `9 13`.
+  - Consequence: The next workflow run must use a merged commit after `6190269606d3c09e97b70db08a9f85ecaf1d861e`.
 
 ## Plan of Work
 
@@ -136,6 +145,11 @@ Additional commands after first rerun:
 ```powershell
 gh run view 27993600431 --repo lowestprime/reynard-browser --log-failed
 gh run view 27993600431 --repo lowestprime/reynard-browser --json databaseId,headSha,headBranch,conclusion,status,url,createdAt,updatedAt,workflowName,jobs
+gh run cancel 27993866717 --repo lowestprime/reynard-browser
+git fetch upstream main
+git merge-base --is-ancestor upstream/main HEAD
+git rev-list --left-right --count upstream/main...HEAD
+git merge upstream/main --no-edit
 ```
 
 ## Validation

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -10,10 +10,10 @@ Produce a verified latest-main Reynard IPA from the `lowestprime/reynard-browser
 
 - [x] The fork is synchronized with or verified against latest upstream `minh-ton/reynard-browser@main`.
 - [ ] GitHub Actions workflow `Build Latest Reynard IPA` completes successfully on `main`.
-- [ ] Artifact `Reynard-latest-main-ipa` is uploaded and downloaded locally.
-- [ ] Downloaded artifact contains `Reynard.ipa`.
-- [ ] IPA contents include `Payload/Reynard.app/Reynard` plus required app extensions.
-- [ ] Build identity is post-0.4.0 and not only public build `63836c3`.
+- [x] Artifact `Reynard-latest-main-ipa` is uploaded and downloaded locally.
+- [x] Downloaded artifact contains `Reynard.ipa`.
+- [x] IPA contents include `Payload/Reynard.app/Reynard` plus required app extensions.
+- [x] Build identity is post-0.4.0 and not only public build `63836c3`.
 - [ ] Page Zoom supports zoom out, zoom in, reset, displayed percentage, per-site persistence where feasible, and a default/global zoom where feasible.
 - [ ] Page Zoom applies to the active tab without restarting the app.
 - [ ] Relevant local checks and final GitHub Actions build are run and recorded.
@@ -30,6 +30,24 @@ Initial `git status --short --branch`:
 ## main...origin/main
 ?? .codex/
 ```
+
+## Verified Baseline IPA
+
+- Patch commit: `5f2bfd48b5611b3601c0b2ff6db040b7d5320e57` (`ci: make Gecko checkpoint inspection pipefail-safe`).
+- Archive-only workflow run: `28036622785`, `https://github.com/lowestprime/reynard-browser/actions/runs/28036622785`.
+- Archive-only run result: success in `7m15s`.
+- Archive job source checkout: `5f2bfd48b5611b3601c0b2ff6db040b7d5320e57`.
+- Reused Gecko checkpoint: `gecko-dist-aarch64-apple-ios` from run `28002185987`.
+- Uploaded artifact: `Reynard-latest-main-ipa`.
+- Local downloaded artifact path: `C:\Users\Cooper\Downloads\Reynard-latest-main-28036622785\Reynard.ipa`.
+- Workflow verification: `dist/Reynard.ipa` existed, was about `105M`, and had SHA-256 `a62f30094cdafe43e426823e961b0d2b98ed59e4f418de8ba3f9265c703b9aab`.
+- Local verification command: `unzip -Z1 C:\Users\Cooper\Downloads\Reynard-latest-main-28036622785\Reynard.ipa`.
+- Verified IPA entries:
+  - `Payload/Reynard.app/Reynard`
+  - `Payload/Reynard.app/PlugIns/Reynard Helper.appex/Info.plist`
+  - `Payload/Reynard.app/PlugIns/OpenIn.appex/Info.plist`
+- Build identity evidence: archive log showed `CURRENT_BUILD=5f2bfd4` and `CURRENT_PROJECT_VERSION=5f2bfd4`, so this is a post-0.4.0 build identity, not only public build `63836c3`.
+- Page Zoom can begin from this verified baseline IPA. The full split `Build Latest Reynard IPA` workflow still has not been rerun after the pipefail-safe patch because the user explicitly prioritized archive-only reuse of the existing Gecko checkpoint.
 
 Recent commits include:
 

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -9,14 +9,14 @@ Produce a verified latest-main Reynard IPA from the `lowestprime/reynard-browser
 ## Success Criteria
 
 - [x] The fork is synchronized with or verified against latest upstream `minh-ton/reynard-browser@main`.
-- [ ] GitHub Actions workflow `Build Latest Reynard IPA` completes successfully on `main`.
+- [x] GitHub Actions workflow `Build Latest Reynard IPA` completes successfully on `main`.
 - [x] Artifact `Reynard-latest-main-ipa` is uploaded and downloaded locally.
 - [x] Downloaded artifact contains `Reynard.ipa`.
 - [x] IPA contents include `Payload/Reynard.app/Reynard` plus required app extensions.
 - [x] Build identity is post-0.4.0 and not only public build `63836c3`.
-- [ ] Page Zoom supports zoom out, zoom in, reset, displayed percentage, per-site persistence where feasible, and a default/global zoom where feasible.
-- [ ] Page Zoom applies to the active tab without restarting the app.
-- [ ] Relevant local checks and final GitHub Actions build are run and recorded.
+- [x] Page Zoom supports zoom out, zoom in, reset, displayed percentage, per-site persistence where feasible, and a default/global zoom where feasible.
+- [x] Page Zoom applies to the active tab without restarting the app.
+- [x] Relevant local checks and final GitHub Actions build are run and recorded.
 
 ## Current State
 
@@ -61,6 +61,27 @@ Current implementation state:
 - Active-tab changes are applied immediately by sending updated `GeckoSessionSettings` to the selected `GeckoSession`.
 - Durable Gecko source behavior is represented as a root-level patch: `patches/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs.patch`. The patch applies `settings.pageZoom` to `browsingContext.fullZoom`.
 - Local Windows validation has confirmed `git diff --check` for tracked changes and `git -C engine/firefox apply --check` for the Gecko patch. Swift/Xcode compilation is deferred to GitHub Actions because this Windows host does not provide `swift` or `xcodebuild`.
+
+## Verified Page Zoom IPA
+
+- Feature commit: `ac7c446aa4a8831579945e4d4cb49a33ce8cf670` (`feat(app): add page zoom controls`).
+- Workflow run: `28038685786`, `https://github.com/lowestprime/reynard-browser/actions/runs/28038685786`.
+- Run result: success in `26m51s`.
+- Build job: `Build Gecko checkpoint`, job ID `82998916130`, success in `20m42s`.
+- Archive job: `Archive IPA from Gecko checkpoint`, job ID `83003479854`, success in `5m52s`.
+- Gecko checkpoint artifact: `gecko-dist-aarch64-apple-ios`, artifact ID `7826642917`, size `124047999` bytes, downloaded by the archive job with SHA-256 `ec43c3d1c73cd81329a8f1a8cb27b7a4722c5e14a7649f036a3867f72a4ef0fa`.
+- IPA artifact: `Reynard-latest-main-ipa`, artifact ID `7826779137`, uploaded artifact zip size `107718673` bytes, uploaded artifact zip SHA-256 `4b75cd47758365e733580b2829234c75af61432d29c451678da1cab718b3be48`.
+- Local downloaded IPA path: `C:\Users\Cooper\Downloads\Reynard-latest-main-28038685786\Reynard.ipa`.
+- Local IPA size: `109612923` bytes.
+- Local IPA SHA-256: `5ee4c3d7259ca22c7b1ce61c072da2a67c328b32137c24e58c02adae9c573291`.
+- Local IPA verification with `unzip -Z1` found `3032` entries and confirmed:
+  - `Payload/Reynard.app/Reynard`
+  - `Payload/Reynard.app/PlugIns/Reynard Helper.appex/Info.plist`
+  - `Payload/Reynard.app/PlugIns/OpenIn.appex/Info.plist`
+- Workflow verification also found the main app binary, `Reynard Helper.appex`, and `OpenIn.appex`.
+- Build identity evidence: archive log showed `CURRENT_BUILD = ac7c446` and `CURRENT_PROJECT_VERSION=ac7c446`, so the IPA is a post-0.4.0 build and not only public build `63836c3`.
+- Acceleration evidence: `actions/cache/restore` restored a `2.44GB` sccache archive from run `28002185987`; `Build Gecko` reported `4645` cache hits, `71` misses, and `98.49%` hit rate. The `.sccache` directory was about `2.7G`; sccache reported `3 GiB` used with an `8 GiB` max.
+- Checkpoint evidence: `engine/firefox/obj-aarch64-apple-ios/dist` was `299M` and uploaded as the `gecko-dist-aarch64-apple-ios` artifact before archive work began.
 
 Recent commits include:
 
@@ -117,8 +138,8 @@ Latest inspected workflow failure:
 - [x] IPA artifact downloaded and inspected.
 - [x] Page Zoom architecture inspected.
 - [x] Page Zoom implemented.
-- [ ] Final Page Zoom build and artifact verified.
-- [ ] Final outcome recorded.
+- [x] Final Page Zoom build and artifact verified.
+- [x] Final outcome recorded.
 
 ## Surprises & Discoveries
 
@@ -136,6 +157,7 @@ Latest inspected workflow failure:
 - Run `28001189594` was started from commit `49556ae` but was cancelled at about 10m27s before entering a long Gecko rebuild. This preserves GitHub runner time while acceleration/checkpointing is added.
 - Run `28001837486` validated the new workflow shape through dependency install, `actions/cache/restore`, Gecko source checkout, patches, idevice FFI, and ld64 detection patching. It failed quickly in `Build Gecko` configure before a long rebuild.
 - The first real error in run `28001837486` was `mozbuild.configure.options.InvalidOptionError: MOZ_LINKER takes 0 values`. The generated `.mozconfig` already had `--enable-linker=ld64`; the problem was leaving the `MOZ_LINKER=ld64` environment variable visible to Firefox configure.
+- Run `28038685786` validated the final Page Zoom build through the full split workflow. Gecko completed in about nine minutes after restoring sccache, the Gecko dist checkpoint was uploaded, the archive job consumed that checkpoint, and `Reynard-latest-main-ipa` uploaded successfully.
 
 ## Decision Log
 
@@ -304,8 +326,8 @@ If later app archive or IPA creation fails, retrieve `Reynard-build-debug` and i
 
 ## Outcomes & Retrospective
 
-- What changed:
-- What passed:
-- What failed or remains unknown:
-- Artifact/run/commit identifiers:
-- Recommended next action:
+- What changed: the workflow now uses sccache restore/save and a Gecko dist checkpoint; Reynard now has Page Zoom controls in the address-bar page menu, default zoom settings, per-host zoom persistence, and a GeckoView patch that applies `pageZoom` through `browsingContext.fullZoom`.
+- What passed: local static checks, Gecko patch application check, the final `Build Latest Reynard IPA` GitHub Actions workflow, artifact upload, artifact download, IPA hash verification, and IPA payload checks.
+- What failed or remains unknown: no current build failure. Physical iOS 26.6 / iPhone 15 Pro Max JIT/TXM behavior and hands-on Page Zoom UX remain device checks.
+- Artifact/run/commit identifiers: feature commit `ac7c446aa4a8831579945e4d4cb49a33ce8cf670`; successful run `28038685786`; IPA artifact `Reynard-latest-main-ipa` ID `7826779137`; local IPA `C:\Users\Cooper\Downloads\Reynard-latest-main-28038685786\Reynard.ipa`.
+- Recommended next action: install the verified IPA on the target device and manually check JIT/TXM behavior plus Page Zoom controls on several sites.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -69,9 +69,10 @@ Latest inspected workflow failure:
 - [x] Latest workflow run and failed log inspected.
 - [x] ExecPlan created.
 - [x] First workflow patch applied for explicit Homebrew `lld` and `wasm-ld` lookup.
-- [ ] Workflow fix committed and pushed.
-- [ ] Workflow rerun started.
-- [ ] Workflow rerun completed.
+- [x] Workflow fix committed and pushed.
+- [x] Workflow rerun started.
+- [x] Workflow rerun completed with a new WASI runtime failure.
+- [x] Second targeted WASI runtime patch applied.
 - [ ] IPA artifact downloaded and inspected.
 - [ ] Page Zoom architecture inspected.
 - [ ] Page Zoom implemented.
@@ -82,6 +83,8 @@ Latest inspected workflow failure:
 
 - The latest failed run was still at commit `c0fa94f22fc8022ed632ef877917688578d9705a`, while local `main` has later AGENTS-only commits. The workflow bug remains in the current workflow file.
 - Homebrew LLVM 22.1.7 on `macos-26` no longer provides `wasm-ld` under `/opt/homebrew/opt/llvm/bin`; Homebrew prints that LLD is a separate formula.
+- Run `27993600431` proved the explicit `lld` patch worked: `command -v wasm-ld` returned `/opt/homebrew/opt/lld/bin/wasm-ld` and `wasm-ld --version` returned `Homebrew LLD 22.1.7`.
+- The same run exposed the next WASI runtime dependency: `/opt/homebrew/opt/llvm/bin/clang --target=wasm32-unknown-wasi --sysroot=/opt/homebrew/share/wasi-sysroot /tmp/wasm-test.c -o /tmp/wasm-test.wasm` failed with `cannot open ... lib/wasm32-unknown-wasi/libclang_rt.builtins.a: No such file or directory`.
 
 ## Decision Log
 
@@ -89,6 +92,10 @@ Latest inspected workflow failure:
   - Reason: The failing log proves `wasm-ld` is missing from the LLVM formula path, and Homebrew says to install `lld`.
   - Evidence: Run `27987957678`, `Install build dependencies`, `/opt/homebrew/opt/llvm/bin/wasm-ld: No such file or directory`.
   - Consequence: The workflow keeps Apple clang for iOS/macOS while exposing LLD only to WASM wrapper commands and the WASM link preflight.
+- Decision: Install Homebrew `wasi-runtimes` and pass its resource dir through the WASM wrappers.
+  - Reason: The next failed log shows `wasm-ld` is now available but clang lacks WASI Compiler-RT builtins. Homebrew describes `wasi-runtimes` as the Compiler-RT and libc++ runtimes for WASI.
+  - Evidence: Run `27993600431`, `Install build dependencies`, `wasm-ld --version` succeeded, then clang failed opening `libclang_rt.builtins.a`.
+  - Consequence: The next run is the one further targeted WASI repair allowed before falling back to `--without-wasm-sandboxed-libraries` if WASI still fails.
 
 ## Plan of Work
 
@@ -122,6 +129,13 @@ git push origin main
 gh workflow run "Build Latest Reynard IPA" --repo lowestprime/reynard-browser --ref main
 gh run list --repo lowestprime/reynard-browser --workflow "Build Latest Reynard IPA" --limit 5
 gh run watch <RUN_ID> --repo lowestprime/reynard-browser
+```
+
+Additional commands after first rerun:
+
+```powershell
+gh run view 27993600431 --repo lowestprime/reynard-browser --log-failed
+gh run view 27993600431 --repo lowestprime/reynard-browser --json databaseId,headSha,headBranch,conclusion,status,url,createdAt,updatedAt,workflowName,jobs
 ```
 
 ## Validation

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -248,6 +248,99 @@ Rollback path:
 - If archive-only download cannot find the run artifact, rerun the main checkpoint workflow once to produce a fresh `gecko-dist-aarch64-apple-ios` artifact and use that run ID.
 - If cache restore/save causes eviction/thrashing, reduce `SCCACHE_CACHE_SIZE` below `8G` or narrow restore keys; do not cache the full Firefox object directory without measured size evidence.
 
+## Feature-Complete UX Batch After Page Zoom Release
+
+Purpose: continue from the verified Page Zoom prerelease and add the next native UX/functionality batch while keeping upstream PR `minh-ton/reynard-browser#153` as the merge path. The previous prerelease remains immutable evidence for the Page Zoom baseline; the next deliverable must be a new verified fork prerelease and an updated PR branch.
+
+Current verified source state:
+
+- Local branch: `main`, tracking `origin/main`.
+- Upstream PR: `https://github.com/minh-ton/reynard-browser/pull/153`.
+- PR source: `lowestprime:main`.
+- PR base: `minh-ton:main`.
+- PR state checked after release: open, non-draft, mergeable.
+- Local `HEAD`: `6f2a03d44c51bd36cc7a836dbd94a5ee33559392` (`docs: record verified Page Zoom IPA build`).
+- Verified app-code release commit: `ac7c446aa4a8831579945e4d4cb49a33ce8cf670`.
+- Verified release: `https://github.com/lowestprime/reynard-browser/releases/tag/reynard-page-zoom-2026-06-23`.
+- Verified run: `28038685786`.
+- Verified artifact: `Reynard-latest-main-ipa`.
+- Verified local IPA: `C:\Users\Cooper\Downloads\Reynard-latest-main-28038685786\Reynard.ipa`.
+- Verified SHA-256: `5ee4c3d7259ca22c7b1ce61c072da2a67c328b32137c24e58c02adae9c573291`.
+
+Feature classification:
+
+- A. Page Zoom refinement: native-app UI/settings logic unless new Gecko behavior is discovered. Expected build path: archive-only using the `gecko-dist-aarch64-apple-ios` checkpoint from run `28038685786`.
+- B. Keyboard/page-content behavior: native UIKit/GeckoView layout and lifecycle logic unless focused-input geometry from Gecko is required. Expected build path: archive-only.
+- C. Background/session preservation and stability: native lifecycle/session/preferences/JIT-state handling with manual physical-device validation for OS/JIT behavior. Expected build path: archive-only.
+- D. Bookmark/history import/export/sync: native app data/storage/UI work. Real Firefox Sync is out of scope unless existing account/protocol support is discovered. Expected build path: archive-only.
+- E. Address bar autocomplete: native address bar suggestions sourced from local bookmarks/history/open tabs/common URL parsing/search fallback. Expected build path: archive-only.
+- F. OLED jet-black theme and accent customization: native settings/theme/accent/resource work. Expected build path: archive-only.
+
+Progress for this continuation:
+
+- [x] New goal objective file read.
+- [x] Root `AGENTS.md` reread.
+- [x] Root `PLANS.md` reread.
+- [x] Existing ExecPlan reread.
+- [x] Local branch and upstream PR source checked.
+- [x] Existing Page Zoom, keyboard, lifecycle/session, bookmark/history, address bar, and theme code inspected.
+- [x] Page Zoom slider refinement implemented.
+- [x] Keyboard/page-content behavior improved.
+- [x] Background/session preservation improvements implemented.
+- [x] Bookmark/history import/export entry points implemented or documented where unsupported.
+- [x] Address bar autocomplete implemented.
+- [x] OLED black theme and accent customization implemented.
+- [x] Local static checks passed.
+- [ ] Archive-only workflow run completed using an existing Gecko checkpoint, or exact evidence recorded for why a full checkpoint run was required.
+- [ ] New IPA downloaded and verified.
+- [ ] New fork prerelease published without overwriting `reynard-page-zoom-2026-06-23`.
+- [ ] Upstream PR `#153` updated and confirmed open/mergeable where possible.
+
+Implemented native-only changes in this continuation:
+
+- Page Zoom: the address-bar page menu now opens a persistent Page Zoom sheet with a slider, zoom out, reset, zoom in, live percent display, and live `GeckoSessionSettings` refresh. Slider mapping/clamping is centralized in `PageZoomLevel`.
+- Keyboard/page content: focused-input relocation clamps Gecko focused-input ratios and uses actual keyboard/content intersection, avoiding unnecessary shifts for non-overlapping/floating keyboard frames.
+- Background/session preservation: app and scene lifecycle notifications now capture the visible tab thumbnail, flush tab/session state, reactivate the selected Gecko session, refresh chrome/navigation state, and reapply page zoom on foreground.
+- Bookmark/history transfer: bookmarks can be imported from Firefox/Netscape-style HTML and exported to HTML; history can be imported/exported as local CSV with privacy confirmations. This is local transfer only and does not claim Firefox Sync.
+- Address bar autocomplete: suggestions now always include local common-domain/URL fallback completions, search-engine suggestions are opt-in in Search settings and debounced, and private browsing no longer surfaces regular history matches.
+- Appearance: Appearance settings now include theme mode, OLED Black, and accent color choices; app windows/chrome/settings/library surfaces apply the selected theme/accent without restart.
+
+Build strategy:
+
+- Avoid Gecko edits for this batch unless inspection proves they are necessary.
+- Reuse a valid `gecko-dist-aarch64-apple-ios` artifact from run `28038685786` through the archive-only workflow for native-only changes.
+- If that checkpoint is expired or unavailable, record the exact artifact lookup/download failure and run the checkpointed full workflow once.
+- Do not leave a long full Gecko build running as passive polling work; if a long build is unavoidable, record a handoff in this ExecPlan.
+
+Validation gates for this continuation:
+
+- `git diff --check`.
+- `bash -n tools/development/build-gecko.sh`.
+- `bash -n tools/release/build-app.sh`.
+- `bash -n browser/Scripts/AddGecko.sh`.
+- YAML parse checks for workflow files if changed.
+- `git -C engine/firefox apply --check <patch>` only if a Gecko patch changes.
+- GitHub Actions archive/build run.
+- Download produced `Reynard.ipa`.
+- `unzip -tq` on the IPA.
+- Verify main app, `Reynard Helper.appex`, `OpenIn.appex`, and `GeckoView.framework/GeckoView` are packaged.
+- Verify feature strings/symbols for new UI where possible.
+- Verify main app and extension build versions match the expected short SHA.
+- Record new IPA SHA-256.
+
+Manual physical-device validation that must not be claimed without evidence:
+
+- Install the new unsigned IPA through the intended sideload flow.
+- Page Zoom slider and plus/minus controls at 75%, 100%, 150%, and 200%.
+- Focus text inputs, textareas, contenteditable fields, and forms with the keyboard visible at 75%, 100%, 150%, and 200%.
+- Background app for 1 minute and return.
+- Background app for 10+ minutes and return.
+- Switch between several tabs after resume.
+- Resume with JIT disabled.
+- Resume with JIT previously enabled.
+- Low-memory or forced relaunch if testable.
+- Verify pages, tabs, zoom, theme/accent, and navigation state remain stable.
+
 ## Plan of Work
 
 First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -132,6 +132,12 @@ Latest inspected workflow failure:
   - Reason: The script needs `MOZ_LINKER` to write durable `.mozconfig`, but Firefox configure rejects the environment variable when it remains set.
   - Evidence: Run `28001837486`, `Build Gecko`, `InvalidOptionError: MOZ_LINKER takes 0 values`.
   - Consequence: The workflow can still set `MOZ_LINKER=ld64`, while `mach build` only sees the supported `--enable-linker=ld64` configure option.
+- Decision: Reuse the Gecko checkpoint from run `28002185987` and repair archive checkpoint inspection only.
+  - Reason: Run `28002185987` completed `Build Gecko checkpoint` and uploaded `gecko-dist-aarch64-apple-ios`; rebuilding Gecko would waste the artifact and reintroduce the slow feedback loop.
+  - Evidence: The archive job downloaded the checkpoint, `engine/firefox/obj-aarch64-apple-ios/dist/bin` existed, `engine/firefox/toolkit/mozapps/extensions/default-theme` existed, and `du -sh engine/firefox/obj-aarch64-apple-ios/dist` reported about `414M`.
+  - Evidence: First-run `sccache` was cold/low-value: restore missed, post-build `sccache -s` showed `Cache hits 0`, `Cache misses 4716`, and the cache directory was about `2.7G`.
+  - Evidence: The archive job then failed after the nonessential diagnostic listing `find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 | head -100` under `set -euo pipefail`.
+  - Consequence: The next action is an archive-only rerun from `run_id=28002185987` after making the diagnostic listing pipefail-safe; Page Zoom remains deferred until the baseline IPA artifact is verified.
 
 ## Build Acceleration Objective
 

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -291,10 +291,10 @@ Progress for this continuation:
 - [x] Address bar autocomplete implemented.
 - [x] OLED black theme and accent customization implemented.
 - [x] Local static checks passed.
-- [ ] Archive-only workflow run completed using an existing Gecko checkpoint, or exact evidence recorded for why a full checkpoint run was required.
-- [ ] New IPA downloaded and verified.
-- [ ] New fork prerelease published without overwriting `reynard-page-zoom-2026-06-23`.
-- [ ] Upstream PR `#153` updated and confirmed open/mergeable where possible.
+- [x] Archive-only workflow run completed using an existing Gecko checkpoint, or exact evidence recorded for why a full checkpoint run was required.
+- [x] New IPA downloaded and verified.
+- [x] New fork prerelease published without overwriting `reynard-page-zoom-2026-06-23`.
+- [x] Upstream PR `#153` updated and confirmed open/mergeable where possible.
 
 Implemented native-only changes in this continuation:
 
@@ -313,6 +313,33 @@ Archive-only validation attempt:
 - First real source error: `ContentView.swift:184` attempted to call `min(max(bottomRatio, 0), 1)` where `GeckoSession.focusedInputBottomRatio()` returns `CGFloat?`.
 - Fix: handle `nil` focused-input geometry by clearing/resetting focused-input relocation, then clamp only non-optional ratios.
 - Repeated local validation after the fix: `git diff --check`, `bash -n tools/development/build-gecko.sh`, `bash -n tools/release/build-app.sh`, and `bash -n browser/Scripts/AddGecko.sh` all returned zero.
+
+Final feature-complete UX IPA validation:
+
+- Final commit: `240928640a1adbab8f9353cc07f35563f10a922b` (`fix(app): handle missing focused input metrics`).
+- Successful archive-only workflow run: `28058553866`, `https://github.com/lowestprime/reynard-browser/actions/runs/28058553866`.
+- Run result: success in `4m26s`.
+- Reused Gecko checkpoint: `gecko-dist-aarch64-apple-ios` from run `28038685786`.
+- Archive job source checkout: `240928640a1adbab8f9353cc07f35563f10a922b`.
+- Uploaded artifact: `Reynard-latest-main-ipa`.
+- Local downloaded IPA: `C:\Users\Cooper\Downloads\Reynard-latest-main-28058553866\Reynard.ipa`.
+- Local IPA size: `109647473` bytes.
+- Local IPA SHA-256: `6c73eb30b8307f82768ad13a20b169ea2ab334e5fea8d37d731d7b2b47593961`.
+- `unzip -tq` passed with no compressed-data errors.
+- ZIP inspection found `3032` entries and `0` duplicate paths.
+- Required packaged entries were present:
+  - `Payload/Reynard.app/Reynard`
+  - `Payload/Reynard.app/PlugIns/Reynard Helper.appex/Info.plist`
+  - `Payload/Reynard.app/PlugIns/OpenIn.appex/Info.plist`
+  - `Payload/Reynard.app/Frameworks/GeckoView.framework/GeckoView`
+- `CFBundleVersion` was `2409286` for the main app, `Reynard Helper.appex`, and `OpenIn.appex`; `CFBundleShortVersionString` was `0.4.0`.
+- Main app, helper extension, OpenIn extension, and GeckoView binaries had Mach-O 64-bit little-endian headers.
+- Feature string scan found `Page Zoom`, `Zoom Out`, `Zoom In`, `Reset`, `OLED Black`, `Search Suggestions`, `Local Suggestions`, `Import Bookmarks`, `Export Bookmarks`, `Site override`, `Firefox/Netscape`, and `Reynard-History.csv`. `Import History` and `Export History` did not appear as plain UTF-8/UTF-16 byte strings even though the history CSV code path compiled and the history CSV filename was present.
+- New fork prerelease: `https://github.com/lowestprime/reynard-browser/releases/tag/reynard-feature-complete-ux-2026-06-23`.
+- Release assets:
+  - `Reynard.ipa`, size `109647473`, digest `sha256:6c73eb30b8307f82768ad13a20b169ea2ab334e5fea8d37d731d7b2b47593961`.
+  - `Reynard.ipa.sha256`, size `77`, digest `sha256:55dfcce7e25e8b0df1adf1b4467c1c18ca19cd0a2301a31c02466148e2f95fff`.
+- Upstream PR `https://github.com/minh-ton/reynard-browser/pull/153` remains open, non-draft, and mergeable with head `240928640a1adbab8f9353cc07f35563f10a922b`.
 
 Build strategy:
 

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -446,6 +446,35 @@ Implementation outcome:
 - Upstream PR `https://github.com/minh-ton/reynard-browser/pull/153` remained open, non-draft, and mergeable when inspected after pushing the keyboard fix.
 - Remaining unknown: real iPhone ChatGPT/Gemini keyboard behavior is not claimed fixed until the user installs this IPA and manually verifies the checklist above.
 
+## Custom Accent Color Follow-Up
+
+Purpose: add full user-selectable accent color customization on top of the verified keyboard-fix release without touching Gecko or rebuilding Gecko.
+
+Baseline:
+
+- Keyboard-fix app-code commit: `9a0fd763b7b1a88cabca93e75cd47411798bc6bd`.
+- Release-record head before this work: `9f5a19a85c8da45b306033166ec580eb49f36e4b`.
+- Keyboard-fix prerelease: `reynard-keyboard-avoidance-fix-2026-06-24`.
+- Successful archive-only run: `28077200523`.
+- Parent PR `https://github.com/minh-ton/reynard-browser/pull/153` was open, non-draft, mergeable, and sourced from `lowestprime:main`.
+
+Target behavior:
+
+- Preserve preset accents: High Contrast, Blue, Orange, Green, and Purple.
+- Add a Custom accent row with a visible square preview and current hex value.
+- Support native `UIColorPickerViewController` on iOS 14+ with alpha disabled.
+- Support manual hex entry for `#RRGGBB` and `RRGGBB`.
+- Persist both the selected accent mode and custom hex color.
+- Apply custom accent immediately through existing `BrowserAppearance.accentColor` consumers.
+- Reject invalid, transparent, or low-contrast custom colors with user-visible feedback while keeping High Contrast available as a fallback.
+
+Implementation plan:
+
+- Extend `BrowserAccentColor` with a `custom` case, preset list, normalized custom hex helper, and lightweight contrast validation against light, dark, and OLED Black backgrounds.
+- Add `Prefs.AppearanceSettings.customAccentHex` with default `#007AFF`.
+- Update `AppearancePreferencesViewController` to show preset rows plus a Custom row, present the system color picker where available, present a hex entry alert, and reload immediately after custom changes.
+- Keep this native-only and validate with the archive-only workflow using Gecko checkpoint run `28038685786`.
+
 ## Plan of Work
 
 First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -1,0 +1,156 @@
+# Reynard latest IPA and Page Zoom
+
+This ExecPlan follows the repository root `PLANS.md`. It must remain current as work proceeds.
+
+## Purpose / Big Picture
+
+Produce a verified latest-main Reynard IPA from the `lowestprime/reynard-browser` fork and then add a discoverable Page Zoom feature that works through Reynard's Gecko-based browsing stack.
+
+## Success Criteria
+
+- [ ] The fork is synchronized with or verified against latest upstream `minh-ton/reynard-browser@main`.
+- [ ] GitHub Actions workflow `Build Latest Reynard IPA` completes successfully on `main`.
+- [ ] Artifact `Reynard-latest-main-ipa` is uploaded and downloaded locally.
+- [ ] Downloaded artifact contains `Reynard.ipa`.
+- [ ] IPA contents include `Payload/Reynard.app/Reynard` plus required app extensions.
+- [ ] Build identity is post-0.4.0 and not only public build `63836c3`.
+- [ ] Page Zoom supports zoom out, zoom in, reset, displayed percentage, per-site persistence where feasible, and a default/global zoom where feasible.
+- [ ] Page Zoom applies to the active tab without restarting the app.
+- [ ] Relevant local checks and final GitHub Actions build are run and recorded.
+
+## Current State
+
+Working directory: `C:\Users\Cooper\Desktop\reynard-browser`.
+
+Branch: `main`, tracking `origin/main`.
+
+Initial `git status --short --branch`:
+
+```text
+## main...origin/main
+?? .codex/
+```
+
+Recent commits include:
+
+```text
+3eb3881 Add Codex agent instructions for Reynard build automation
+454565e Add Codex agent instructions for Reynard build automation
+c0fa94f Expose wasm-ld for Gecko WASI linker
+```
+
+Latest inspected workflow failure:
+
+- Run ID: `27987957678`
+- URL: `https://github.com/lowestprime/reynard-browser/actions/runs/27987957678`
+- Branch: `main`
+- Head SHA: `c0fa94f22fc8022ed632ef877917688578d9705a`
+- Failed step: `Install build dependencies`
+- Exact failing line: `/opt/homebrew/opt/llvm/bin/wasm-ld --version`
+- Exact error: `/opt/homebrew/opt/llvm/bin/wasm-ld: No such file or directory`
+- Important preceding Homebrew caveat: `LLD is now provided in a separate formula: brew install lld`
+
+## Constraints
+
+- Do not use `engine/firefox` as the project root.
+- Do not commit arbitrary durable changes inside `engine/firefox`; use root workflow, `tools/`, or `patches/`.
+- Keep Apple/Xcode clang as `CC`, `CXX`, `HOST_CC`, and `HOST_CXX` unless logs prove a change is required.
+- Use Homebrew LLVM/LLD only for WASM/WASI compiler/linker plumbing.
+- Do not use unknown third-party IPAs as final success without verified provenance.
+- Continue the build/log/patch loop autonomously until success or a real external blocker.
+- If WASI linking still fails after explicit `lld` and one targeted repair, document the exact error before using `--without-wasm-sandboxed-libraries`.
+
+## Progress
+
+- [x] Goal objective read.
+- [x] Root `AGENTS.md` read.
+- [x] Root `PLANS.md` read.
+- [x] CI-fix skill instructions read.
+- [x] Latest workflow run and failed log inspected.
+- [x] ExecPlan created.
+- [x] First workflow patch applied for explicit Homebrew `lld` and `wasm-ld` lookup.
+- [ ] Workflow fix committed and pushed.
+- [ ] Workflow rerun started.
+- [ ] Workflow rerun completed.
+- [ ] IPA artifact downloaded and inspected.
+- [ ] Page Zoom architecture inspected.
+- [ ] Page Zoom implemented.
+- [ ] Final Page Zoom build and artifact verified.
+- [ ] Final outcome recorded.
+
+## Surprises & Discoveries
+
+- The latest failed run was still at commit `c0fa94f22fc8022ed632ef877917688578d9705a`, while local `main` has later AGENTS-only commits. The workflow bug remains in the current workflow file.
+- Homebrew LLVM 22.1.7 on `macos-26` no longer provides `wasm-ld` under `/opt/homebrew/opt/llvm/bin`; Homebrew prints that LLD is a separate formula.
+
+## Decision Log
+
+- Decision: Install Homebrew `lld` explicitly and find `wasm-ld` through `command -v`.
+  - Reason: The failing log proves `wasm-ld` is missing from the LLVM formula path, and Homebrew says to install `lld`.
+  - Evidence: Run `27987957678`, `Install build dependencies`, `/opt/homebrew/opt/llvm/bin/wasm-ld: No such file or directory`.
+  - Consequence: The workflow keeps Apple clang for iOS/macOS while exposing LLD only to WASM wrapper commands and the WASM link preflight.
+
+## Plan of Work
+
+First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.
+
+If the workflow fails, retrieve failed logs and the debug artifact if available, identify the exact failing lines, update this plan, patch the smallest root cause, commit, push, and rerun.
+
+After the IPA workflow is green and the artifact is downloaded and inspected, inspect Reynard's tab/session/settings/menu/GeckoView architecture before implementing Page Zoom. Prefer Gecko/session preference support; add conservative fallback behavior only if the current iOS GeckoView layer lacks true page zoom. Then run local validation available on Windows and final GitHub Actions validation.
+
+## Concrete Steps
+
+Commands run so far:
+
+```powershell
+git status --short --branch
+git log --oneline -10
+gh auth status
+gh run list --repo lowestprime/reynard-browser --workflow "Build Latest Reynard IPA" --limit 5
+gh run view 27987957678 --repo lowestprime/reynard-browser --json databaseId,headSha,headBranch,conclusion,status,url,createdAt,updatedAt,event,workflowName,displayTitle
+gh run view 27987957678 --repo lowestprime/reynard-browser --log-failed
+```
+
+Next commands:
+
+```powershell
+git diff --check
+git diff -- .github/workflows/build-latest-reynard-ipa.yml .agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+git add .github/workflows/build-latest-reynard-ipa.yml .agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+git commit -m "ci: expose Homebrew lld for Gecko WASI"
+git push origin main
+gh workflow run "Build Latest Reynard IPA" --repo lowestprime/reynard-browser --ref main
+gh run list --repo lowestprime/reynard-browser --workflow "Build Latest Reynard IPA" --limit 5
+gh run watch <RUN_ID> --repo lowestprime/reynard-browser
+```
+
+## Validation
+
+Build validation:
+
+- Workflow `Build Latest Reynard IPA` must complete successfully.
+- Artifact `Reynard-latest-main-ipa` must exist for the successful run.
+- Downloaded artifact must contain `Reynard.ipa`.
+- `unzip -l Reynard.ipa` must show the main app and required extensions.
+
+Feature validation:
+
+- Local static/build checks available on Windows must pass or be documented if unavailable.
+- Final GitHub Actions build after Page Zoom must upload a fresh IPA artifact.
+- Physical iPhone checks for iOS 26.6 Developer Beta 2, SideStore, LocalDevVPN, and JIT/TXM remain manual unless the device is available.
+
+## Recovery / Fallbacks
+
+If explicit `lld` still cannot expose `wasm-ld`, inspect `brew --prefix lld`, `ls /opt/homebrew/opt/lld/bin`, and `command -v wasm-ld` from the failed run logs or debug artifact, then patch the wrapper path once.
+
+If WASI compile succeeds but link fails after that targeted repair, switch Gecko mozconfig generation from `--with-wasi-sysroot=/opt/homebrew/share/wasi-sysroot` to `--without-wasm-sandboxed-libraries` and record the exact log lines that justify the fallback.
+
+If later app archive or IPA creation fails, retrieve `Reynard-build-debug` and inspect Xcode logs, `dist`, `browser/Configuration/Reynard.xcconfig`, and app extension packaging before patching.
+
+## Outcomes & Retrospective
+
+- What changed:
+- What passed:
+- What failed or remains unknown:
+- Artifact/run/commit identifiers:
+- Recommended next action:

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -80,7 +80,9 @@ Latest inspected workflow failure:
 - [x] Copy Gecko Stuff signing failure root cause identified.
 - [x] Copy Gecko Stuff unsigned-archive fix committed and pushed as `49556ae`.
 - [x] Unaccelerated rerun `28001189594` cancelled before another full Gecko rebuild.
-- [ ] Gecko build caching and checkpointing implemented and rerun.
+- [x] Gecko build caching and checkpointing implemented and first rerun attempted.
+- [x] Fast configure failure in run `28001837486` identified and patched.
+- [ ] Checkpointed workflow rerun succeeds through Gecko artifact upload.
 - [ ] IPA artifact downloaded and inspected.
 - [ ] Page Zoom architecture inspected.
 - [ ] Page Zoom implemented.
@@ -101,6 +103,8 @@ Latest inspected workflow failure:
 - Run `27994353614` proved the Gecko build now completes, then failed in `Build Reynard app archive` after 3h6m47s. The first real archive error was in `PhaseScriptExecution Copy Gecko Stuff`: `Apple Development: no identity found`, followed by `Command PhaseScriptExecution failed with a nonzero exit code`.
 - The failing script was `browser/Scripts/AddGecko.sh`. It used `SIGN_IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:-${EXPANDED_CODE_SIGN_IDENTITY_NAME:-Apple Development}}"` and invoked `codesign` unconditionally, even though the workflow archive command passed `CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
 - Run `28001189594` was started from commit `49556ae` but was cancelled at about 10m27s before entering a long Gecko rebuild. This preserves GitHub runner time while acceleration/checkpointing is added.
+- Run `28001837486` validated the new workflow shape through dependency install, `actions/cache/restore`, Gecko source checkout, patches, idevice FFI, and ld64 detection patching. It failed quickly in `Build Gecko` configure before a long rebuild.
+- The first real error in run `28001837486` was `mozbuild.configure.options.InvalidOptionError: MOZ_LINKER takes 0 values`. The generated `.mozconfig` already had `--enable-linker=ld64`; the problem was leaving the `MOZ_LINKER=ld64` environment variable visible to Firefox configure.
 
 ## Decision Log
 
@@ -124,6 +128,10 @@ Latest inspected workflow failure:
   - Reason: Run `27994353614` already proved the expensive Gecko compile passes; repeating it for every archive-stage failure creates a 2.5-3 hour feedback loop.
   - Evidence: Run `28001189594` was only about ten minutes old when cancelled, while `27994353614` spent roughly 2h53m in `Build Gecko` before the later archive failure.
   - Consequence: The next workflow run must include `sccache`, a saved Gecko dist checkpoint, and an archive job/path that can retry IPA packaging without rebuilding Gecko.
+- Decision: Consume and unset `MOZ_LINKER` inside `tools/development/build-gecko.sh`.
+  - Reason: The script needs `MOZ_LINKER` to write durable `.mozconfig`, but Firefox configure rejects the environment variable when it remains set.
+  - Evidence: Run `28001837486`, `Build Gecko`, `InvalidOptionError: MOZ_LINKER takes 0 values`.
+  - Consequence: The workflow can still set `MOZ_LINKER=ld64`, while `mach build` only sees the supported `--enable-linker=ld64` configure option.
 
 ## Build Acceleration Objective
 
@@ -230,6 +238,8 @@ gh api repos/minh-ton/reynard-browser/forks --paginate --jq '.[] | {full_name, p
 gh run view 27994353614 --repo lowestprime/reynard-browser --log-failed
 gh run download 27994353614 --repo lowestprime/reynard-browser --name Reynard-build-debug --dir "$env:USERPROFILE\Desktop\reynard-build-debug-latest"
 gh run cancel 28001189594 --repo lowestprime/reynard-browser
+gh run view 28001837486 --repo lowestprime/reynard-browser --log-failed
+gh run download 28001837486 --repo lowestprime/reynard-browser --name Reynard-build-debug-gecko --dir "$env:USERPROFILE\Desktop\reynard-build-debug-28001837486"
 ```
 
 ## Validation

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -377,6 +377,46 @@ Manual physical-device validation that must not be claimed without evidence:
 - Low-memory or forced relaunch if testable.
 - Verify pages, tabs, zoom, theme/accent, and navigation state remain stable.
 
+## Keyboard Obstruction Regression Fix
+
+Purpose: repair the remaining real-device regression where bottom-fixed page composers and focused page inputs can stay hidden behind the iOS keyboard and Reynard bottom chrome on the latest feature-complete IPA. This is a targeted native-only continuation; Page Zoom, bookmark/history transfer, autocomplete, theme work, and release plumbing should not be reimplemented except where validation requires it.
+
+User evidence to preserve:
+
+- `https://chatgpt.com`: the ChatGPT input composer/page content remains partly hidden behind the iOS keyboard and/or bottom browser chrome when the keyboard opens.
+- `https://gemini.google.com`: the Gemini bottom composer is visible with the keyboard closed, but keyboard open leaves page composer/content obscured instead of repositioned into the visible viewport.
+- This affects bottom-fixed modern web-app composers, not only ordinary scrollable form fields.
+- The prior focused-input relocation batch is incomplete because it depends on Gecko focused-input geometry and resets when that geometry is nil.
+
+Current inspected implementation:
+
+- `BrowserViewController.keyboardFrameWillChange(_:)` computes keyboard overlap and only calls `ContentView.relocateFocusedInput(above:)` for page keyboard events.
+- `ContentView.relocateFocusedInput(above:)` asks Gecko for `focusedInputBottomRatio()` and translates the content with `focusedInputOffset` when a focused editable metric exists.
+- If Gecko returns nil focused-input geometry, `ContentView` resets focused-input relocation, so bottom-fixed SPA composers get no fallback.
+- The normal phone content bottom is anchored to `browserChrome.bottomToolbarTopAnchor`; when the software keyboard covers the bottom of the app, that anchor can still sit underneath the keyboard, leaving the Gecko viewport too tall for bottom-fixed page UI.
+
+Fix design:
+
+- Keep the change native-only so the archive-only workflow can reuse Gecko checkpoint run `28038685786`.
+- Add a real page viewport bottom inset to `ContentView` and drive it from the actual intersection between the root view, current content view frame, and keyboard frame.
+- Treat focused-input metrics as a secondary correction. Values above `1.0` are allowed because Gecko's patch reports a viewport-relative bottom ratio up to `2.0`; values above `1.0` mean the focused editable is below the currently visible viewport.
+- Keep native address bar/search keyboard behavior separate: when the native address bar is focused, reset page keyboard avoidance and keep docking the address bar above the keyboard.
+- Recompute keyboard avoidance on keyboard show/hide/frame changes, layout changes, foreground restore, and Page Zoom preference changes.
+
+Manual test checklist for the fixed IPA:
+
+- Gemini keyboard closed: bottom composer visible.
+- Gemini keyboard open: composer remains above keyboard and bottom chrome.
+- ChatGPT keyboard open: composer remains above keyboard and bottom chrome.
+- Repeat at 75%, 100%, 150%, and 200% page zoom.
+- Rotate device if feasible.
+- Background/foreground after keyboard use.
+- JIT disabled.
+- JIT previously enabled if available.
+- Native address bar editing still works.
+- Autocomplete overlay still works.
+- Page Zoom sheet stays open while pressing plus/minus or moving the slider.
+
 ## Plan of Work
 
 First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -305,6 +305,15 @@ Implemented native-only changes in this continuation:
 - Address bar autocomplete: suggestions now always include local common-domain/URL fallback completions, search-engine suggestions are opt-in in Search settings and debounced, and private browsing no longer surfaces regular history matches.
 - Appearance: Appearance settings now include theme mode, OLED Black, and accent color choices; app windows/chrome/settings/library surfaces apply the selected theme/accent without restart.
 
+Archive-only validation attempt:
+
+- Run `28058053384` used archive-only workflow `Archive Reynard IPA From Gecko Dist` at commit `7fe5048ecbbbe89873970a144aed0d7e07de53c3` with Gecko checkpoint run `28038685786`.
+- The checkpoint path was proven: checkout, archive dependency install, Gecko dist artifact download, checkpoint inspection, and idevice FFI all succeeded without a Gecko rebuild.
+- The archive failed in `Build Reynard app archive` with Xcode exit `65`.
+- First real source error: `ContentView.swift:184` attempted to call `min(max(bottomRatio, 0), 1)` where `GeckoSession.focusedInputBottomRatio()` returns `CGFloat?`.
+- Fix: handle `nil` focused-input geometry by clearing/resetting focused-input relocation, then clamp only non-optional ratios.
+- Repeated local validation after the fix: `git diff --check`, `bash -n tools/development/build-gecko.sh`, `bash -n tools/release/build-app.sh`, and `bash -n browser/Scripts/AddGecko.sh` all returned zero.
+
 Build strategy:
 
 - Avoid Gecko edits for this batch unless inspection proves they are necessary.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -417,6 +417,35 @@ Manual test checklist for the fixed IPA:
 - Autocomplete overlay still works.
 - Page Zoom sheet stays open while pressing plus/minus or moving the slider.
 
+Implementation outcome:
+
+- Keyboard fix commit: `9a0fd763b7b1a88cabca93e75cd47411798bc6bd` (`fix(app): avoid keyboard-obscured page composers`).
+- Native-only code changes:
+  - `browser/Reynard/Client/Interface/BrowserViewController.swift` now computes keyboard avoidance from the root view, safe-area bottom inset, keyboard frame, and a pre-avoidance content reference frame.
+  - `browser/Reynard/Client/Interface/ContentView/ContentView.swift` now applies a real page viewport bottom inset before using Gecko focused-input metrics as a secondary correction.
+- Local validation:
+  - `git diff --check` passed.
+  - `bash -n tools/development/build-gecko.sh` passed.
+  - `bash -n tools/release/build-app.sh` passed.
+  - `bash -n browser/Scripts/AddGecko.sh` passed.
+  - `swift` and `xcodebuild` were unavailable on the Windows host, so Swift compilation was validated by GitHub Actions.
+- Archive-only workflow run: `28077200523`, `https://github.com/lowestprime/reynard-browser/actions/runs/28077200523`.
+- Run result: success in `7m46s`.
+- Reused Gecko checkpoint: `gecko-dist-aarch64-apple-ios` from run `28038685786`; no full Gecko rebuild was triggered.
+- Uploaded artifact: `Reynard-latest-main-ipa`.
+- Local downloaded IPA: `C:\Users\Cooper\Downloads\Reynard-latest-main-28077200523\Reynard.ipa`.
+- Local IPA size: `109647702` bytes.
+- Local IPA SHA-256: `a9e6f147312444cb1c834913f6fe9b71716690d49fc15ef085235c7cdb65c972`.
+- `unzip -tq` passed with no compressed-data errors.
+- ZIP/plist/Mach-O inspection found `3032` entries, `0` duplicate paths, required app/extensions/GeckoView entries, `CFBundleVersion` `9a0fd76` for the main app and extensions, and arm64 Mach-O headers.
+- Marker scan found Page Zoom, OLED Black, search/local suggestions, bookmark import/export, history CSV, and the new `pageViewportBottomInset` symbol marker.
+- New fork prerelease: `https://github.com/lowestprime/reynard-browser/releases/tag/reynard-keyboard-avoidance-fix-2026-06-24`.
+- Release assets:
+  - `Reynard.ipa`, size `109647702`, digest `sha256:a9e6f147312444cb1c834913f6fe9b71716690d49fc15ef085235c7cdb65c972`.
+  - `Reynard.ipa.sha256`, size `77`, digest `sha256:5d76a1c74da7b43a211a746cc59d4d28ababd5eae9f21003b6137ec294083a22`.
+- Upstream PR `https://github.com/minh-ton/reynard-browser/pull/153` remained open, non-draft, and mergeable when inspected after pushing the keyboard fix.
+- Remaining unknown: real iPhone ChatGPT/Gemini keyboard behavior is not claimed fixed until the user installs this IPA and manually verifies the checklist above.
+
 ## Plan of Work
 
 First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -78,7 +78,9 @@ Latest inspected workflow failure:
 - [x] Quick upstream/fork release audit completed; no clearly newer downloadable IPA was found.
 - [x] Latest-main run `27994353614` completed Gecko and failed in Xcode archive signing.
 - [x] Copy Gecko Stuff signing failure root cause identified.
-- [ ] Copy Gecko Stuff unsigned-archive fix committed and rerun.
+- [x] Copy Gecko Stuff unsigned-archive fix committed and pushed as `49556ae`.
+- [x] Unaccelerated rerun `28001189594` cancelled before another full Gecko rebuild.
+- [ ] Gecko build caching and checkpointing implemented and rerun.
 - [ ] IPA artifact downloaded and inspected.
 - [ ] Page Zoom architecture inspected.
 - [ ] Page Zoom implemented.
@@ -98,6 +100,7 @@ Latest inspected workflow failure:
 - A quick GitHub release/fork audit found upstream releases only through `0.4.0`, and sampled recent forks did not expose newer release assets. No third-party IPA has better provenance than completing this fork's workflow.
 - Run `27994353614` proved the Gecko build now completes, then failed in `Build Reynard app archive` after 3h6m47s. The first real archive error was in `PhaseScriptExecution Copy Gecko Stuff`: `Apple Development: no identity found`, followed by `Command PhaseScriptExecution failed with a nonzero exit code`.
 - The failing script was `browser/Scripts/AddGecko.sh`. It used `SIGN_IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:-${EXPANDED_CODE_SIGN_IDENTITY_NAME:-Apple Development}}"` and invoked `codesign` unconditionally, even though the workflow archive command passed `CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
+- Run `28001189594` was started from commit `49556ae` but was cancelled at about 10m27s before entering a long Gecko rebuild. This preserves GitHub runner time while acceleration/checkpointing is added.
 
 ## Decision Log
 
@@ -117,6 +120,66 @@ Latest inspected workflow failure:
   - Reason: The workflow intentionally builds an unsigned SideStore IPA and already passes Xcode signing suppression flags; the copy script must not invent `Apple Development` when no identity exists.
   - Evidence: Run `27994353614`, `Build Reynard app archive`, `Apple Development: no identity found`.
   - Consequence: Local signed Xcode builds can still sign Gecko artifacts when Xcode provides an identity, while CI unsigned archives can proceed to IPA packaging.
+- Decision: Stop rerunning the monolithic workflow and add caching/checkpointing before the next build.
+  - Reason: Run `27994353614` already proved the expensive Gecko compile passes; repeating it for every archive-stage failure creates a 2.5-3 hour feedback loop.
+  - Evidence: Run `28001189594` was only about ten minutes old when cancelled, while `27994353614` spent roughly 2h53m in `Build Gecko` before the later archive failure.
+  - Consequence: The next workflow run must include `sccache`, a saved Gecko dist checkpoint, and an archive job/path that can retry IPA packaging without rebuilding Gecko.
+
+## Build Acceleration Objective
+
+Baseline timing evidence:
+
+- Run `27994353614`: total job time was 3h6m52s.
+- `Build Gecko` started at `2026-06-23T01:01:27Z`; `Build Reynard app archive` started at `2026-06-23T03:54:26Z`, so the successful Gecko step took about 2h53m wall time on the free `macos-26` runner.
+- The first post-Gecko failure was archive-stage signing in `browser/Scripts/AddGecko.sh`, proving archive and IPA debugging should not require another full Gecko compile.
+- Run `28001189594` was cancelled at about 10m27s before the long Gecko build repeated.
+
+macOS-only stages:
+
+- Final `xcodebuild archive`, iPhoneOS SDK usage, `xcrun`, app-extension validation, `ldid` IPA packaging, and all direct use of Xcode must stay on a macOS runner.
+- Gecko iOS target compilation currently depends on Apple/Xcode clang for host/target paths and must remain on macOS unless a separate toolchain experiment proves otherwise.
+
+Cacheable/checkpointable stages:
+
+- Gecko C/C++/Rust object compilation can use local `sccache` on the macOS runner.
+- The `sccache` directory is capped at `8G` and keyed by runner OS/arch, `engine/release.txt`, the workflow file, `tools/development/build-gecko.sh`, and patch hashes.
+- `engine/firefox/obj-aarch64-apple-ios/dist` plus `engine/firefox/toolkit/mozapps/extensions/default-theme` is uploaded as short-retention artifact `gecko-dist-aarch64-apple-ios` after a successful Gecko build.
+
+WSL2 feasibility:
+
+- The user's ThinkPad has i7-12800H, 14 cores / 20 logical processors, 64 GB RAM, and NVMe SSD, so it is a strong candidate for a Linux `sccache-dist` worker for compatible compile actions.
+- WSL2 must not run Xcode, iPhoneOS SDK, `xcrun`, signing, or IPA packaging.
+- WSL2 distributed compilation is not considered working until `sccache --dist-status` and `sccache -s` show useful distributed compilations. If distributed compilations remain zero, WSL acceleration has not worked.
+- Tailscale or equivalent network setup would require user-provided credentials/secrets. Exact likely GitHub secrets, if pursued later, are `SCCACHE_DIST_AUTH_TOKEN`, `TAILSCALE_AUTHKEY`, and a server address/port value such as `SCCACHE_DIST_SCHEDULER_URL`; these are not guessed or added in this pass.
+
+Exact workflow/script changes:
+
+- `tools/development/build-gecko.sh` now honors `MOZ_BUILD_JOBS`, `MOZ_LINKER`, `WASI_SYSROOT`, and executable `SCCACHE_BIN`, writes matching `.mozconfig` options, runs `./mach build -j "$MOZ_BUILD_JOBS"`, and prints `sccache -s` before/after.
+- `.github/workflows/build-latest-reynard-ipa.yml` is split into `build-gecko` and `archive-ipa` jobs.
+- `build-gecko` installs `sccache`, restores/saves `.sccache`, builds Gecko, records cache size/statistics, and uploads `gecko-dist-aarch64-apple-ios`.
+- `archive-ipa` downloads `gecko-dist-aarch64-apple-ios`, rebuilds idevice FFI, archives with `REYNARD_UNSIGNED_ARCHIVE=1`, creates/verifies the IPA, and uploads `Reynard-latest-main-ipa`.
+- `.github/workflows/archive-reynard-ipa-from-gecko-dist.yml` is a manual archive-only diagnostic workflow with a required `run_id` input that downloads a prior Gecko checkpoint artifact.
+
+Validation commands:
+
+```powershell
+bash -n tools/development/build-gecko.sh
+bash -n tools/release/build-app.sh
+bash -n browser/Scripts/AddGecko.sh
+git diff --check
+gh workflow run "Build Latest Reynard IPA" --repo lowestprime/reynard-browser --ref main
+gh run watch <RUN_ID> --repo lowestprime/reynard-browser
+gh run view <RUN_ID> --repo lowestprime/reynard-browser --log-failed
+gh run download <RUN_ID> --repo lowestprime/reynard-browser --name gecko-dist-aarch64-apple-ios --dir "$env:USERPROFILE\Desktop\reynard-gecko-dist-latest"
+gh workflow run "Archive Reynard IPA From Gecko Dist" --repo lowestprime/reynard-browser --ref main -f run_id=<RUN_ID>
+```
+
+Rollback path:
+
+- If `sccache` breaks configure/build, remove the `CCACHE=$SCCACHE_BIN` `.mozconfig` option and keep the split checkpoint artifact.
+- If the Gecko dist artifact is too large or incomplete, keep local `sccache` and temporarily merge the archive job back into the Gecko job while recording the artifact size/failure.
+- If archive-only download cannot find the run artifact, rerun the main checkpoint workflow once to produce a fresh `gecko-dist-aarch64-apple-ios` artifact and use that run ID.
+- If cache restore/save causes eviction/thrashing, reduce `SCCACHE_CACHE_SIZE` below `8G` or narrow restore keys; do not cache the full Firefox object directory without measured size evidence.
 
 ## Plan of Work
 
@@ -166,6 +229,7 @@ gh api repos/minh-ton/reynard-browser/releases --paginate --jq '.[] | {tag_name,
 gh api repos/minh-ton/reynard-browser/forks --paginate --jq '.[] | {full_name, pushed_at, default_branch, html_url}'
 gh run view 27994353614 --repo lowestprime/reynard-browser --log-failed
 gh run download 27994353614 --repo lowestprime/reynard-browser --name Reynard-build-debug --dir "$env:USERPROFILE\Desktop\reynard-build-debug-latest"
+gh run cancel 28001189594 --repo lowestprime/reynard-browser
 ```
 
 ## Validation

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -503,6 +503,39 @@ Implementation outcome:
   - `Reynard.ipa.sha256`, size `77`, digest `sha256:bdb475a409e2dfdbdba2e6feafb7c6594eb57d5d07255f6fc03cb55a20b495f8`.
 - Remaining manual validation: install the IPA on iPhone and check Appearance > Accent presets plus Custom, picker, hex entry, persistence, theme coverage, Page Zoom, and the keyboard fix.
 
+## Background Resume Black Tab Regression Fix
+
+Purpose: fix a high-priority native lifecycle regression where returning to Reynard after using other apps can leave tabs black, non-interactive, or missing. This is a native resume/session-state repair only; Page Zoom remains implemented and must be preserved, and no Gecko rebuild should be triggered unless the archive-only path proves insufficient.
+
+Regression evidence and current state:
+
+- Parent PR `https://github.com/minh-ton/reynard-browser/pull/153` is still open, non-draft, mergeable, and sourced from `lowestprime:main`.
+- Current fork head before this fix is `2aaa124ead814b9dbd9466bedd527127a04f4c06`, which records the custom accent IPA release.
+- Existing lifecycle hooks save tab state on scene/app resign active, background, memory warning, and termination, but the tab store writes normal state asynchronously.
+- `SceneDelegate.sceneDidDisconnect` does not flush browser state.
+- Foreground restore currently reactivates the selected Gecko session and reapplies chrome, Page Zoom, layout, and keyboard avoidance, but it does not distinguish a closed/crashed/detached/non-renderable session from a healthy session.
+- `TabManagerImplementation.onCrash` and `onKill` currently remove the crashed/killed tab, matching the reported "lost tabs" failure mode.
+- JIT can remain volatile across backgrounding; this fix must keep non-JIT browsing usable by replacing or reloading broken tab sessions from persisted URLs instead of leaving black content.
+
+Targeted implementation:
+
+- Make lifecycle tab-state flushes synchronous so the last selected-tab and open-tab snapshot is durable before iOS background suspension.
+- Save on scene disconnect in addition to existing app and scene lifecycle notifications.
+- Preserve tabs on Gecko crash/kill by replacing the tab's Gecko session in place, keeping the tab ID, URL, title, privacy mode, navigation history, Page Zoom/site settings, and UI selection.
+- On foreground, ensure the selected tab exists, has an open Gecko session, is activated, is attached to the visible content view, and has page settings reapplied.
+- If the selected content view is detached, zero-sized, hidden, or non-interactive after foreground layout, reattach it; if it still cannot render, replace the selected session once from the persisted URL as a conservative black-tab recovery path.
+- Reapply theme/accent, Page Zoom, keyboard avoidance, and browser layout after recovery.
+
+Validation plan:
+
+- Run `git diff --check`.
+- Run `bash -n tools/development/build-gecko.sh`.
+- Run `bash -n tools/release/build-app.sh`.
+- Run `bash -n browser/Scripts/AddGecko.sh`.
+- Use the archive-only workflow with the existing valid Gecko checkpoint, download the IPA, run `unzip -tq`, verify app/extensions/GeckoView entries, confirm `CFBundleVersion` equals the short app commit SHA, and calculate SHA-256.
+- Publish a fork prerelease for the background resume fix and update PR #153 with the new release and validation evidence.
+- Manual device validation remains required for long iOS 26.6 background/resume behavior, JIT enabled/disabled behavior, and true black-frame compositor recovery on a physical iPhone.
+
 ## Plan of Work
 
 First repair `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step installs `lld`, prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands, uses `command -v wasm-ld`, and validates a real WASM link using the Homebrew WASI sysroot. Commit, push, trigger the workflow, and inspect the result.

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -75,6 +75,10 @@ Latest inspected workflow failure:
 - [x] Second targeted WASI runtime patch applied.
 - [x] Non-final run confirmed dependencies passed and reached `Build Gecko`.
 - [x] Latest upstream `minh-ton/reynard-browser@main` merged.
+- [x] Quick upstream/fork release audit completed; no clearly newer downloadable IPA was found.
+- [x] Latest-main run `27994353614` completed Gecko and failed in Xcode archive signing.
+- [x] Copy Gecko Stuff signing failure root cause identified.
+- [ ] Copy Gecko Stuff unsigned-archive fix committed and rerun.
 - [ ] IPA artifact downloaded and inspected.
 - [ ] Page Zoom architecture inspected.
 - [ ] Page Zoom implemented.
@@ -90,6 +94,10 @@ Latest inspected workflow failure:
 - Run `27993866717` passed `Install build dependencies`, `Update Gecko source`, `Apply Gecko patches`, `Build idevice FFI`, and `Force Gecko to use Xcode ld64`; it reached `Build Gecko` before being intentionally canceled because the fork had not yet merged latest upstream main.
 - After `git fetch upstream main`, `upstream/main...HEAD` was `9 13`, proving the fork was missing nine upstream commits. The upstream head was `0fcee2c40f8629c50a9481419dfb9184c75c0236` (`Hide tab bar when in iPad 1/3 split screen`).
 - `git merge upstream/main --no-edit` completed without conflicts and produced merge commit `6190269606d3c09e97b70db08a9f85ecaf1d861e`; `git merge-base --is-ancestor upstream/main HEAD` then confirmed upstream is contained in the fork.
+- Run `27994353614` uses head SHA `b37d9a14ce07b3e01e65891cb8ab2e808e74984e`, which includes the upstream merge and the build-plan update. The job passed dependency installation, Gecko source checkout, patch application, idevice FFI, and ld64 patching, then remained in `Build Gecko` for more than two hours with no live logs exposed by `gh`.
+- A quick GitHub release/fork audit found upstream releases only through `0.4.0`, and sampled recent forks did not expose newer release assets. No third-party IPA has better provenance than completing this fork's workflow.
+- Run `27994353614` proved the Gecko build now completes, then failed in `Build Reynard app archive` after 3h6m47s. The first real archive error was in `PhaseScriptExecution Copy Gecko Stuff`: `Apple Development: no identity found`, followed by `Command PhaseScriptExecution failed with a nonzero exit code`.
+- The failing script was `browser/Scripts/AddGecko.sh`. It used `SIGN_IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:-${EXPANDED_CODE_SIGN_IDENTITY_NAME:-Apple Development}}"` and invoked `codesign` unconditionally, even though the workflow archive command passed `CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`.
 
 ## Decision Log
 
@@ -105,6 +113,10 @@ Latest inspected workflow failure:
   - Reason: A successful artifact from that run would not have satisfied the latest-main requirement because upstream/main was not contained in the fork.
   - Evidence: `git rev-list --left-right --count upstream/main...HEAD` returned `9 13`.
   - Consequence: The next workflow run must use a merged commit after `6190269606d3c09e97b70db08a9f85ecaf1d861e`.
+- Decision: Make `browser/Scripts/AddGecko.sh` skip Gecko artifact signing for unsigned archives.
+  - Reason: The workflow intentionally builds an unsigned SideStore IPA and already passes Xcode signing suppression flags; the copy script must not invent `Apple Development` when no identity exists.
+  - Evidence: Run `27994353614`, `Build Reynard app archive`, `Apple Development: no identity found`.
+  - Consequence: Local signed Xcode builds can still sign Gecko artifacts when Xcode provides an identity, while CI unsigned archives can proceed to IPA packaging.
 
 ## Plan of Work
 
@@ -150,6 +162,10 @@ git fetch upstream main
 git merge-base --is-ancestor upstream/main HEAD
 git rev-list --left-right --count upstream/main...HEAD
 git merge upstream/main --no-edit
+gh api repos/minh-ton/reynard-browser/releases --paginate --jq '.[] | {tag_name, name, published_at, target_commitish, assets: [.assets[] | {name, browser_download_url, size}]}'
+gh api repos/minh-ton/reynard-browser/forks --paginate --jq '.[] | {full_name, pushed_at, default_branch, html_url}'
+gh run view 27994353614 --repo lowestprime/reynard-browser --log-failed
+gh run download 27994353614 --repo lowestprime/reynard-browser --name Reynard-build-debug --dir "$env:USERPROFILE\Desktop\reynard-build-debug-latest"
 ```
 
 ## Validation

--- a/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
+++ b/.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md
@@ -49,6 +49,19 @@ Initial `git status --short --branch`:
 - Build identity evidence: archive log showed `CURRENT_BUILD=5f2bfd4` and `CURRENT_PROJECT_VERSION=5f2bfd4`, so this is a post-0.4.0 build identity, not only public build `63836c3`.
 - Page Zoom can begin from this verified baseline IPA. The full split `Build Latest Reynard IPA` workflow still has not been rerun after the pipefail-safe patch because the user explicitly prioritized archive-only reuse of the existing Gecko checkpoint.
 
+## Page Zoom Implementation
+
+Current implementation state:
+
+- Reynard's tab/session/settings/menu architecture has been inspected. The feature is wired through the existing `SessionSettingsManager`, `GeckoSessionSettings`, address-bar page menu, and browsing settings screens.
+- The page menu exposes `Page Zoom` controls for host-backed pages: zoom out, current percentage, zoom in, and reset to the configured default.
+- Zoom levels are normalized to `50%, 75%, 85%, 100%, 115%, 125%, 150%, 175%, 200%, 250%, 300%`.
+- Default zoom is stored under `Prefs.BrowsingSettings.defaultPageZoomPercent`.
+- Site-specific overrides are stored under `Prefs.BrowsingSettings.pageZoomOverrides`, keyed by normalized host and matched through existing `DomainMatcher` behavior.
+- Active-tab changes are applied immediately by sending updated `GeckoSessionSettings` to the selected `GeckoSession`.
+- Durable Gecko source behavior is represented as a root-level patch: `patches/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs.patch`. The patch applies `settings.pageZoom` to `browsingContext.fullZoom`.
+- Local Windows validation has confirmed `git diff --check` for tracked changes and `git -C engine/firefox apply --check` for the Gecko patch. Swift/Xcode compilation is deferred to GitHub Actions because this Windows host does not provide `swift` or `xcodebuild`.
+
 Recent commits include:
 
 ```text
@@ -100,10 +113,10 @@ Latest inspected workflow failure:
 - [x] Unaccelerated rerun `28001189594` cancelled before another full Gecko rebuild.
 - [x] Gecko build caching and checkpointing implemented and first rerun attempted.
 - [x] Fast configure failure in run `28001837486` identified and patched.
-- [ ] Checkpointed workflow rerun succeeds through Gecko artifact upload.
-- [ ] IPA artifact downloaded and inspected.
-- [ ] Page Zoom architecture inspected.
-- [ ] Page Zoom implemented.
+- [x] Checkpointed workflow rerun succeeds through Gecko artifact upload.
+- [x] IPA artifact downloaded and inspected.
+- [x] Page Zoom architecture inspected.
+- [x] Page Zoom implemented.
 - [ ] Final Page Zoom build and artifact verified.
 - [ ] Final outcome recorded.
 

--- a/.github/workflows/archive-reynard-ipa-from-gecko-dist.yml
+++ b/.github/workflows/archive-reynard-ipa-from-gecko-dist.yml
@@ -68,7 +68,7 @@ jobs:
           test -d engine/firefox/obj-aarch64-apple-ios/dist/bin
           test -d engine/firefox/toolkit/mozapps/extensions/default-theme
           du -sh engine/firefox/obj-aarch64-apple-ios/dist
-          find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 | head -100
+          find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 -print | sed -n '1,100p'
 
       - name: Build idevice FFI
         shell: zsh {0}

--- a/.github/workflows/archive-reynard-ipa-from-gecko-dist.yml
+++ b/.github/workflows/archive-reynard-ipa-from-gecko-dist.yml
@@ -1,0 +1,121 @@
+name: Archive Reynard IPA From Gecko Dist
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: GitHub Actions run ID containing gecko-dist-aarch64-apple-ios
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  archive-ipa:
+    name: Archive IPA from existing Gecko dist
+    runs-on: macos-26
+    timeout-minutes: 90
+
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
+
+    steps:
+      - name: Checkout Reynard
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Show archive identity
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git rev-parse --short HEAD
+          git log -1 --oneline
+          sw_vers
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-path
+
+      - name: Install archive dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew list ldid >/dev/null 2>&1 || brew install ldid
+          rustup target add aarch64-apple-ios
+
+      - name: Make scripts executable
+        shell: bash
+        run: |
+          set -euxo pipefail
+          chmod +x tools/development/*.sh
+          chmod +x tools/release/*.sh
+
+      - name: Download Gecko dist checkpoint
+        uses: actions/download-artifact@v4
+        with:
+          name: gecko-dist-aarch64-apple-ios
+          path: engine/firefox
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.run_id }}
+
+      - name: Inspect Gecko checkpoint
+        shell: bash
+        run: |
+          set -euxo pipefail
+          test -d engine/firefox/obj-aarch64-apple-ios/dist/bin
+          test -d engine/firefox/toolkit/mozapps/extensions/default-theme
+          du -sh engine/firefox/obj-aarch64-apple-ios/dist
+          find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 | head -100
+
+      - name: Build idevice FFI
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+          ./tools/development/build-idevice.sh
+
+      - name: Build Reynard app archive
+        shell: bash
+        env:
+          REYNARD_UNSIGNED_ARCHIVE: "1"
+        run: |
+          set -euxo pipefail
+          ./tools/release/build-app.sh
+
+      - name: Create IPA
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ./tools/release/create-ipa.sh || test -f dist/Reynard.ipa
+
+      - name: Verify IPA
+        shell: bash
+        run: |
+          set -euxo pipefail
+          test -f dist/Reynard.ipa
+          ls -lah dist/Reynard.ipa
+          shasum -a 256 dist/Reynard.ipa
+          unzip -l dist/Reynard.ipa | tee /tmp/Reynard.ipa.list
+          grep -E 'Payload/Reynard.app/Reynard$' /tmp/Reynard.ipa.list
+          grep -E 'Payload/Reynard.app/PlugIns/Reynard Helper.appex/(Reynard Helper|Info.plist)$' /tmp/Reynard.ipa.list
+          grep -E 'Payload/Reynard.app/PlugIns/OpenIn.appex/(OpenIn|Info.plist)$' /tmp/Reynard.ipa.list
+
+      - name: Upload Reynard IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Reynard-latest-main-ipa
+          path: dist/Reynard.ipa
+          retention-days: 14
+
+      - name: Upload logs and dist for debugging
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Reynard-build-debug
+          path: |
+            dist
+            engine/release.txt
+            browser/Configuration/Reynard.xcconfig
+          retention-days: 7

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -15,6 +15,7 @@ jobs:
 
     env:
       HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_ENV_HINTS: "1"
       MOZBUILD_STATE_PATH: /Users/runner/.mozbuild
       MOZCONFIG: /Users/runner/work/reynard-browser/reynard-browser/engine/firefox/.mozconfig
 
@@ -34,18 +35,15 @@ jobs:
           sw_vers
           xcodebuild -version
           xcrun --sdk iphoneos --show-sdk-path
+          /usr/bin/clang --version
+          /usr/bin/clang++ --version
 
       - name: Install build dependencies
         shell: bash
         run: |
           set -euxo pipefail
           brew list ldid >/dev/null 2>&1 || brew install ldid
-          brew list llvm >/dev/null 2>&1 || brew install llvm
           rustup target add aarch64-apple-ios
-          echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
-          /opt/homebrew/opt/llvm/bin/clang --version
-          /opt/homebrew/opt/llvm/bin/ld64.lld --version || true
-          /opt/homebrew/opt/llvm/bin/ld.lld --version || true
 
       - name: Make scripts executable
         shell: bash
@@ -72,42 +70,72 @@ jobs:
           set -euxo pipefail
           ./tools/development/build-idevice.sh
 
-      - name: Force Gecko to use Homebrew LLVM/lld
+      - name: Force Gecko to use Xcode ld64
         shell: bash
         run: |
           set -euxo pipefail
+
           python3 - <<'PY'
           from pathlib import Path
 
+          # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64,
+          # not lld. This is the correct Darwin/iOS linker family for Xcode.
           p = Path("tools/development/build-gecko.sh")
           s = p.read_text()
 
           needle = 'echo "ac_add_options --target=$TARGET"\n'
           insert = '''echo "ac_add_options --target=$TARGET"
-            echo "CC=/opt/homebrew/opt/llvm/bin/clang"
-            echo "CXX=/opt/homebrew/opt/llvm/bin/clang++"
-            echo "HOST_CC=/opt/homebrew/opt/llvm/bin/clang"
-            echo "HOST_CXX=/opt/homebrew/opt/llvm/bin/clang++"
-            echo "ac_add_options --enable-linker=lld"
+            echo "ac_add_options --enable-linker=ld64"
           '''
 
           if needle not in s:
               raise SystemExit("Expected target line not found in tools/development/build-gecko.sh")
 
           p.write_text(s.replace(needle, insert, 1))
+
+          # 2) Patch Mozilla's linker probe for modern Xcode/macOS runners.
+          # ld64 does not reliably identify itself through the old -Wl,--version
+          # + LD_PRINT_OPTIONS probe, even though the compiler/linker path is valid.
+          q = Path("engine/firefox/build/moz.configure/toolchain.configure")
+          t = q.read_text()
+
+          old = '''        if retcode == 1 and "Logging ld64 options" in stderr:
+                      kind = "ld64"
+
+                  elif retcode != 0:
+                      return None
+          '''
+
+          new = '''        if linker == "ld64" and target.kernel == "Darwin" and retcode != 0:
+                      kind = "ld64"
+
+                  elif retcode == 1 and "Logging ld64 options" in stderr:
+                      kind = "ld64"
+
+                  elif retcode != 0:
+                      return None
+          '''
+
+          if old not in t:
+              raise SystemExit("Expected ld64 detection block not found in Firefox toolchain.configure")
+
+          q.write_text(t.replace(old, new, 1))
           PY
 
           echo "Patched build-gecko.sh:"
-          sed -n '1,120p' tools/development/build-gecko.sh
+          sed -n '1,90p' tools/development/build-gecko.sh
+
+          echo "Patched linker detection block:"
+          grep -n -A14 -B4 'linker == "ld64"' engine/firefox/build/moz.configure/toolchain.configure
 
       - name: Build Gecko
         shell: bash
         env:
-          PATH: /opt/homebrew/opt/llvm/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
-          CC: /opt/homebrew/opt/llvm/bin/clang
-          CXX: /opt/homebrew/opt/llvm/bin/clang++
-          HOST_CC: /opt/homebrew/opt/llvm/bin/clang
-          HOST_CXX: /opt/homebrew/opt/llvm/bin/clang++
+          PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+          CC: /usr/bin/clang
+          CXX: /usr/bin/clang++
+          HOST_CC: /usr/bin/clang
+          HOST_CXX: /usr/bin/clang++
         run: |
           set -euxo pipefail
           ./tools/development/build-gecko.sh

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -272,7 +272,7 @@ jobs:
           test -d engine/firefox/obj-aarch64-apple-ios/dist/bin
           test -d engine/firefox/toolkit/mozapps/extensions/default-theme
           du -sh engine/firefox/obj-aarch64-apple-ios/dist
-          find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 | head -100
+          find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 -print | sed -n '1,100p'
 
       - name: Build idevice FFI
         shell: zsh {0}

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -44,9 +44,19 @@ jobs:
           set -euxo pipefail
           brew list ldid >/dev/null 2>&1 || brew install ldid
           brew list cbindgen >/dev/null 2>&1 || brew install cbindgen
+          brew list llvm >/dev/null 2>&1 || brew install llvm
+          brew list wasi-libc >/dev/null 2>&1 || brew install wasi-libc
+
           rustup target add aarch64-apple-ios
+
           echo "CBINDGEN=/opt/homebrew/bin/cbindgen" >> "$GITHUB_ENV"
+          echo "WASM_CC=/opt/homebrew/opt/llvm/bin/clang" >> "$GITHUB_ENV"
+          echo "WASM_CXX=/opt/homebrew/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
+
           /opt/homebrew/bin/cbindgen --version
+          /opt/homebrew/opt/llvm/bin/clang --version
+          /opt/homebrew/opt/llvm/bin/clang --target=wasm32-wasi -c -x c /dev/null -o /tmp/wasm-test.o
+          ls -lah /tmp/wasm-test.o
 
       - name: Make scripts executable
         shell: bash
@@ -87,7 +97,8 @@ jobs:
           s = p.read_text()
 
           target_line = 'echo "ac_add_options --target=$TARGET"'
-          ld64_line = '  echo "ac_add_options --enable-linker=ld64"'
+          ld64_line = '''  echo "ac_add_options --enable-linker=ld64"
+          echo "ac_add_options --with-wasi-sysroot=/opt/homebrew/share/wasi-sysroot"'''
 
           if ld64_line not in s:
               if target_line not in s:

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -48,6 +48,7 @@ jobs:
           brew list llvm >/dev/null 2>&1 || brew install llvm
           brew list lld >/dev/null 2>&1 || brew install lld
           brew list wasi-libc >/dev/null 2>&1 || brew install wasi-libc
+          brew list wasi-runtimes >/dev/null 2>&1 || brew install wasi-runtimes
 
           rustup target add aarch64-apple-ios
 
@@ -57,13 +58,13 @@ jobs:
           cat > "$WASI_WRAPPER_DIR/clang" <<'SH'
           #!/usr/bin/env bash
           export PATH="/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin:$PATH"
-          exec /opt/homebrew/opt/llvm/bin/clang "$@"
+          exec /opt/homebrew/opt/llvm/bin/clang -resource-dir=/opt/homebrew/share/wasi-runtimes "$@"
           SH
 
           cat > "$WASI_WRAPPER_DIR/clang++" <<'SH'
           #!/usr/bin/env bash
           export PATH="/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin:$PATH"
-          exec /opt/homebrew/opt/llvm/bin/clang++ "$@"
+          exec /opt/homebrew/opt/llvm/bin/clang++ -resource-dir=/opt/homebrew/share/wasi-runtimes "$@"
           SH
 
           chmod +x "$WASI_WRAPPER_DIR/clang" "$WASI_WRAPPER_DIR/clang++"
@@ -78,13 +79,19 @@ jobs:
           command -v wasm-ld
           wasm-ld --version
           test -d /opt/homebrew/share/wasi-sysroot
+          test -f /opt/homebrew/share/wasi-runtimes/lib/wasm32-unknown-wasi/libclang_rt.builtins.a
           ls -lah /opt/homebrew/share/wasi-sysroot
+          /opt/homebrew/opt/llvm/bin/clang \
+            -resource-dir=/opt/homebrew/share/wasi-runtimes \
+            --target=wasm32-unknown-wasi \
+            --print-resource-dir
 
           cat > /tmp/wasm-test.c <<'C'
           int main(void) { return 0; }
           C
 
           /opt/homebrew/opt/llvm/bin/clang \
+            -resource-dir=/opt/homebrew/share/wasi-runtimes \
             --target=wasm32-unknown-wasi \
             --sysroot=/opt/homebrew/share/wasi-sysroot \
             /tmp/wasm-test.c \

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -46,6 +46,7 @@ jobs:
           brew list ldid >/dev/null 2>&1 || brew install ldid
           brew list cbindgen >/dev/null 2>&1 || brew install cbindgen
           brew list llvm >/dev/null 2>&1 || brew install llvm
+          brew list lld >/dev/null 2>&1 || brew install lld
           brew list wasi-libc >/dev/null 2>&1 || brew install wasi-libc
 
           rustup target add aarch64-apple-ios
@@ -55,13 +56,13 @@ jobs:
 
           cat > "$WASI_WRAPPER_DIR/clang" <<'SH'
           #!/usr/bin/env bash
-          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+          export PATH="/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin:$PATH"
           exec /opt/homebrew/opt/llvm/bin/clang "$@"
           SH
 
           cat > "$WASI_WRAPPER_DIR/clang++" <<'SH'
           #!/usr/bin/env bash
-          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+          export PATH="/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin:$PATH"
           exec /opt/homebrew/opt/llvm/bin/clang++ "$@"
           SH
 
@@ -73,7 +74,9 @@ jobs:
 
           /opt/homebrew/bin/cbindgen --version
           /opt/homebrew/opt/llvm/bin/clang --version
-          /opt/homebrew/opt/llvm/bin/wasm-ld --version
+          PATH="/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin:$PATH"
+          command -v wasm-ld
+          wasm-ld --version
           test -d /opt/homebrew/share/wasi-sysroot
           ls -lah /opt/homebrew/share/wasi-sysroot
 
@@ -81,8 +84,7 @@ jobs:
           int main(void) { return 0; }
           C
 
-          PATH="/opt/homebrew/opt/llvm/bin:$PATH" \
-            /opt/homebrew/opt/llvm/bin/clang \
+          /opt/homebrew/opt/llvm/bin/clang \
             --target=wasm32-unknown-wasi \
             --sysroot=/opt/homebrew/share/wasi-sysroot \
             /tmp/wasm-test.c \

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -43,7 +43,10 @@ jobs:
         run: |
           set -euxo pipefail
           brew list ldid >/dev/null 2>&1 || brew install ldid
+          brew list cbindgen >/dev/null 2>&1 || brew install cbindgen
           rustup target add aarch64-apple-ios
+          echo "CBINDGEN=/opt/homebrew/bin/cbindgen" >> "$GITHUB_ENV"
+          /opt/homebrew/bin/cbindgen --version
 
       - name: Make scripts executable
         shell: bash

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -78,55 +78,41 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
 
-          # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64,
-          # not lld. This is the correct Darwin/iOS linker family for Xcode.
+          # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64.
           p = Path("tools/development/build-gecko.sh")
           s = p.read_text()
 
-          needle = 'echo "ac_add_options --target=$TARGET"\n'
-          insert = '''echo "ac_add_options --target=$TARGET"
-            echo "ac_add_options --enable-linker=ld64"
-          '''
+          target_line = 'echo "ac_add_options --target=$TARGET"'
+          ld64_line = '  echo "ac_add_options --enable-linker=ld64"'
 
-          if needle not in s:
-              raise SystemExit("Expected target line not found in tools/development/build-gecko.sh")
+          if ld64_line not in s:
+              if target_line not in s:
+                  raise SystemExit("Expected target line not found in tools/development/build-gecko.sh")
+              s = s.replace(target_line, target_line + "\n" + ld64_line, 1)
+              p.write_text(s)
 
-          p.write_text(s.replace(needle, insert, 1))
-
-          # 2) Patch Mozilla's linker probe for modern Xcode/macOS runners.
-          # ld64 does not reliably identify itself through the old -Wl,--version
-          # + LD_PRINT_OPTIONS probe, even though the compiler/linker path is valid.
+          # 2) Patch Firefox 152 linker detection with a robust single-line anchor.
           q = Path("engine/firefox/build/moz.configure/toolchain.configure")
           t = q.read_text()
 
-          old = '''        if retcode == 1 and "Logging ld64 options" in stderr:
+          anchor = 'if retcode == 1 and "Logging ld64 options" in stderr:'
+          replacement = '''if linker == "ld64" and target.kernel == "Darwin" and retcode != 0:
                       kind = "ld64"
+                  elif retcode == 1 and "Logging ld64 options" in stderr:'''
 
-                  elif retcode != 0:
-                      return None
-          '''
+          if replacement not in t:
+              if anchor not in t:
+                  raise SystemExit("ld64 anchor line not found in Firefox toolchain.configure")
+              t = t.replace(anchor, replacement, 1)
+              q.write_text(t)
 
-          new = '''        if linker == "ld64" and target.kernel == "Darwin" and retcode != 0:
-                      kind = "ld64"
-
-                  elif retcode == 1 and "Logging ld64 options" in stderr:
-                      kind = "ld64"
-
-                  elif retcode != 0:
-                      return None
-          '''
-
-          if old not in t:
-              raise SystemExit("Expected ld64 detection block not found in Firefox toolchain.configure")
-
-          q.write_text(t.replace(old, new, 1))
           PY
 
           echo "Patched build-gecko.sh:"
-          sed -n '1,90p' tools/development/build-gecko.sh
+          sed -n '1,100p' tools/development/build-gecko.sh
 
-          echo "Patched linker detection block:"
-          grep -n -A14 -B4 'linker == "ld64"' engine/firefox/build/moz.configure/toolchain.configure
+          echo "Patched linker detection context:"
+          grep -n -A10 -B6 'Logging ld64 options' engine/firefox/build/moz.configure/toolchain.configure
 
       - name: Build Gecko
         shell: bash

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -77,6 +77,7 @@ jobs:
 
           python3 - <<'PY'
           from pathlib import Path
+          import re
 
           # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64.
           p = Path("tools/development/build-gecko.sh")
@@ -91,21 +92,31 @@ jobs:
               s = s.replace(target_line, target_line + "\n" + ld64_line, 1)
               p.write_text(s)
 
-          # 2) Patch Firefox 152 linker detection with a robust single-line anchor.
+          # 2) Patch Firefox linker detection while preserving real indentation.
           q = Path("engine/firefox/build/moz.configure/toolchain.configure")
           t = q.read_text()
 
-          anchor = 'if retcode == 1 and "Logging ld64 options" in stderr:'
-          replacement = '''if linker == "ld64" and target.kernel == "Darwin" and retcode != 0:
-                      kind = "ld64"
-                  elif retcode == 1 and "Logging ld64 options" in stderr:'''
+          pattern = r'^(?P<indent>[ \t]*)if retcode == 1 and "Logging ld64 options" in stderr:\n(?P=indent)[ \t]+kind = "ld64"'
+          m = re.search(pattern, t, flags=re.MULTILINE)
 
-          if replacement not in t:
-              if anchor not in t:
-                  raise SystemExit("ld64 anchor line not found in Firefox toolchain.configure")
-              t = t.replace(anchor, replacement, 1)
-              q.write_text(t)
+          if not m:
+              raise SystemExit("Could not find exact ld64 detection block with indentation")
 
+          indent = m.group("indent")
+          child = indent + "    "
+
+          replacement = (
+              f'{indent}if linker == "ld64" and target.kernel == "Darwin" and retcode != 0:\n'
+              f'{child}kind = "ld64"\n'
+              f'{indent}elif retcode == 1 and "Logging ld64 options" in stderr:\n'
+              f'{child}kind = "ld64"'
+          )
+
+          t = t[:m.start()] + replacement + t[m.end():]
+          q.write_text(t)
+
+          # 3) Validate patched Python syntax before wasting another run.
+          compile(q.read_text(), str(q), "exec")
           PY
 
           echo "Patched build-gecko.sh:"

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -7,23 +7,29 @@ permissions:
   contents: read
   actions: read
 
+env:
+  HOMEBREW_NO_AUTO_UPDATE: "1"
+  HOMEBREW_NO_ENV_HINTS: "1"
+  MOZBUILD_STATE_PATH: /Users/runner/.mozbuild
+  MOZCONFIG: ${{ github.workspace }}/engine/firefox/.mozconfig
+  MOZ_BUILD_JOBS: "12"
+  MOZ_LINKER: ld64
+  SCCACHE_BIN: /opt/homebrew/bin/sccache
+  SCCACHE_CACHE_SIZE: 8G
+  SCCACHE_DIR: ${{ github.workspace }}/.sccache
+  SCCACHE_IDLE_TIMEOUT: "0"
+  WASI_SYSROOT: /opt/homebrew/share/wasi-sysroot
+
 jobs:
-  build:
-    name: Build unsigned SideStore IPA from latest main
+  build-gecko:
+    name: Build Gecko checkpoint
     runs-on: macos-26
     timeout-minutes: 360
-
-    env:
-      HOMEBREW_NO_AUTO_UPDATE: "1"
-      HOMEBREW_NO_ENV_HINTS: "1"
-      MOZBUILD_STATE_PATH: /Users/runner/.mozbuild
-      MOZCONFIG: /Users/runner/work/reynard-browser/reynard-browser/engine/firefox/.mozconfig
 
     steps:
       - name: Checkout Reynard
         uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 1
 
       - name: Show build identity
@@ -38,7 +44,7 @@ jobs:
           /usr/bin/clang --version
           /usr/bin/clang++ --version
 
-      - name: Install build dependencies
+      - name: Install Gecko build dependencies
         shell: bash
         run: |
           set -euxo pipefail
@@ -47,13 +53,14 @@ jobs:
           brew list cbindgen >/dev/null 2>&1 || brew install cbindgen
           brew list llvm >/dev/null 2>&1 || brew install llvm
           brew list lld >/dev/null 2>&1 || brew install lld
+          brew list sccache >/dev/null 2>&1 || brew install sccache
           brew list wasi-libc >/dev/null 2>&1 || brew install wasi-libc
           brew list wasi-runtimes >/dev/null 2>&1 || brew install wasi-runtimes
 
           rustup target add aarch64-apple-ios
 
           WASI_WRAPPER_DIR="$RUNNER_TEMP/wasi-bin"
-          mkdir -p "$WASI_WRAPPER_DIR"
+          mkdir -p "$WASI_WRAPPER_DIR" "$SCCACHE_DIR"
 
           cat > "$WASI_WRAPPER_DIR/clang" <<'SH'
           #!/usr/bin/env bash
@@ -74,13 +81,14 @@ jobs:
           echo "WASM_CXX=$WASI_WRAPPER_DIR/clang++" >> "$GITHUB_ENV"
 
           /opt/homebrew/bin/cbindgen --version
+          /opt/homebrew/bin/sccache --version
           /opt/homebrew/opt/llvm/bin/clang --version
           PATH="/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin:$PATH"
           command -v wasm-ld
           wasm-ld --version
-          test -d /opt/homebrew/share/wasi-sysroot
+          test -d "$WASI_SYSROOT"
           test -f /opt/homebrew/share/wasi-runtimes/lib/wasm32-unknown-wasi/libclang_rt.builtins.a
-          ls -lah /opt/homebrew/share/wasi-sysroot
+          ls -lah "$WASI_SYSROOT"
           /opt/homebrew/opt/llvm/bin/clang \
             -resource-dir=/opt/homebrew/share/wasi-runtimes \
             --target=wasm32-unknown-wasi \
@@ -93,11 +101,20 @@ jobs:
           /opt/homebrew/opt/llvm/bin/clang \
             -resource-dir=/opt/homebrew/share/wasi-runtimes \
             --target=wasm32-unknown-wasi \
-            --sysroot=/opt/homebrew/share/wasi-sysroot \
+            --sysroot="$WASI_SYSROOT" \
             /tmp/wasm-test.c \
             -o /tmp/wasm-test.wasm
 
           ls -lah /tmp/wasm-test.wasm
+
+      - name: Restore sccache
+        uses: actions/cache/restore@v4
+        with:
+          path: .sccache
+          key: gecko-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('engine/release.txt', '.github/workflows/build-latest-reynard-ipa.yml', 'tools/development/build-gecko.sh', 'patches/**/*.patch') }}-${{ github.run_id }}
+          restore-keys: |
+            gecko-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('engine/release.txt', '.github/workflows/build-latest-reynard-ipa.yml', 'tools/development/build-gecko.sh', 'patches/**/*.patch') }}-
+            gecko-sccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Make scripts executable
         shell: bash
@@ -124,7 +141,7 @@ jobs:
           set -euxo pipefail
           ./tools/development/build-idevice.sh
 
-      - name: Force Gecko to use Xcode ld64
+      - name: Patch Firefox ld64 detection
         shell: bash
         run: |
           set -euxo pipefail
@@ -132,27 +149,6 @@ jobs:
           python3 - <<'PY'
           from pathlib import Path
 
-          # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64
-          # for the iOS target linker.
-          p = Path("tools/development/build-gecko.sh")
-          s = p.read_text()
-
-          target_line = 'echo "ac_add_options --target=$TARGET"'
-          ld64_line = '''  echo "ac_add_options --enable-linker=ld64"
-          echo "ac_add_options --with-wasi-sysroot=/opt/homebrew/share/wasi-sysroot"'''
-
-          if ld64_line not in s:
-              if target_line not in s:
-                  raise SystemExit("Expected target line not found in tools/development/build-gecko.sh")
-              s = s.replace(target_line, target_line + "\n" + ld64_line, 1)
-              p.write_text(s)
-
-          # 2) Patch Firefox linker detection for both:
-          #    - explicit target linker: linker == "ld64"
-          #    - implicit host linker fallback: linker is None
-          #
-          # Do NOT accept linker == "lld" here. The host probe tries lld first,
-          # and only the no-explicit-linker fallback should be treated as Xcode ld64.
           q = Path("engine/firefox/build/moz.configure/toolchain.configure")
           t = q.read_text()
 
@@ -174,12 +170,8 @@ jobs:
 
               q.write_text("\n".join(lines) + "\n")
 
-          # 3) Validate patched Python syntax before running configure.
           compile(q.read_text(), str(q), "exec")
           PY
-
-          echo "Patched build-gecko.sh:"
-          sed -n '1,100p' tools/development/build-gecko.sh
 
           echo "Patched linker detection context:"
           grep -n -A12 -B6 'Logging ld64 options' engine/firefox/build/moz.configure/toolchain.configure
@@ -194,29 +186,104 @@ jobs:
           HOST_CXX: /usr/bin/clang++
         run: |
           set -euxo pipefail
+          mkdir -p "$SCCACHE_DIR"
+          du -sh "$SCCACHE_DIR" || true
+          "$SCCACHE_BIN" -s || true
           ./tools/development/build-gecko.sh
+          "$SCCACHE_BIN" -s || true
+          du -sh "$SCCACHE_DIR" || true
+          du -sh engine/firefox/obj-aarch64-apple-ios/dist
 
-      - name: Disable Xcode code signing for archive
+      - name: Save sccache
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: .sccache
+          key: gecko-sccache-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('engine/release.txt', '.github/workflows/build-latest-reynard-ipa.yml', 'tools/development/build-gecko.sh', 'patches/**/*.patch') }}-${{ github.run_id }}
+
+      - name: Upload Gecko dist checkpoint
+        uses: actions/upload-artifact@v4
+        with:
+          name: gecko-dist-aarch64-apple-ios
+          path: |
+            engine/firefox/obj-aarch64-apple-ios/dist
+            engine/firefox/toolkit/mozapps/extensions/default-theme
+          if-no-files-found: error
+          retention-days: 3
+
+      - name: Upload Gecko build debug
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Reynard-build-debug-gecko
+          path: |
+            engine/release.txt
+            engine/firefox/.mozconfig
+            engine/firefox/config.log
+            engine/firefox/obj-aarch64-apple-ios/.mozbuild/logs
+          retention-days: 7
+
+  archive-ipa:
+    name: Archive IPA from Gecko checkpoint
+    runs-on: macos-26
+    needs: build-gecko
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout Reynard
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Show archive identity
         shell: bash
         run: |
           set -euxo pipefail
-          python3 - <<'PY'
-          from pathlib import Path
+          git rev-parse --short HEAD
+          git log -1 --oneline
+          sw_vers
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-path
 
-          p = Path("tools/release/build-app.sh")
-          s = p.read_text()
+      - name: Install archive dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew list ldid >/dev/null 2>&1 || brew install ldid
+          rustup target add aarch64-apple-ios
 
-          old = '-configuration Release -xcconfig "$DIST_DIR/Reynard.xcconfig"'
-          new = '-configuration Release -xcconfig "$DIST_DIR/Reynard.xcconfig" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""'
+      - name: Make scripts executable
+        shell: bash
+        run: |
+          set -euxo pipefail
+          chmod +x tools/development/*.sh
+          chmod +x tools/release/*.sh
 
-          if old not in s:
-              raise SystemExit("Expected xcodebuild argument string not found in tools/release/build-app.sh")
+      - name: Download Gecko dist checkpoint
+        uses: actions/download-artifact@v4
+        with:
+          name: gecko-dist-aarch64-apple-ios
+          path: engine/firefox
 
-          p.write_text(s.replace(old, new, 1))
-          PY
+      - name: Inspect Gecko checkpoint
+        shell: bash
+        run: |
+          set -euxo pipefail
+          test -d engine/firefox/obj-aarch64-apple-ios/dist/bin
+          test -d engine/firefox/toolkit/mozapps/extensions/default-theme
+          du -sh engine/firefox/obj-aarch64-apple-ios/dist
+          find engine/firefox/obj-aarch64-apple-ios/dist -maxdepth 2 | head -100
+
+      - name: Build idevice FFI
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+          ./tools/development/build-idevice.sh
 
       - name: Build Reynard app archive
         shell: bash
+        env:
+          REYNARD_UNSIGNED_ARCHIVE: "1"
         run: |
           set -euxo pipefail
           ./tools/release/build-app.sh
@@ -234,7 +301,10 @@ jobs:
           test -f dist/Reynard.ipa
           ls -lah dist/Reynard.ipa
           shasum -a 256 dist/Reynard.ipa
-          unzip -l dist/Reynard.ipa | grep -E 'Payload/Reynard.app/(Reynard|PlugIns/Reynard Helper.appex|PlugIns/OpenIn.appex)' || true
+          unzip -l dist/Reynard.ipa | tee /tmp/Reynard.ipa.list
+          grep -E 'Payload/Reynard.app/Reynard$' /tmp/Reynard.ipa.list
+          grep -E 'Payload/Reynard.app/PlugIns/Reynard Helper.appex/(Reynard Helper|Info.plist)$' /tmp/Reynard.ipa.list
+          grep -E 'Payload/Reynard.app/PlugIns/OpenIn.appex/(OpenIn|Info.plist)$' /tmp/Reynard.ipa.list
 
       - name: Upload Reynard IPA
         uses: actions/upload-artifact@v4
@@ -251,8 +321,5 @@ jobs:
           path: |
             dist
             engine/release.txt
-            engine/firefox/.mozconfig
-            engine/firefox/config.log
-            engine/firefox/obj-aarch64-apple-ios/.mozbuild/logs
             browser/Configuration/Reynard.xcconfig
           retention-days: 7

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -1,0 +1,128 @@
+name: Build Latest Reynard IPA
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  build:
+    name: Build unsigned SideStore IPA from latest main
+    runs-on: macos-26
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout Reynard
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Show build identity
+        shell: bash
+        run: |
+          set -euxo pipefail
+          git rev-parse --short HEAD
+          git log -1 --oneline
+          sw_vers
+          xcodebuild -version
+          xcrun --sdk iphoneos --show-sdk-path
+
+      - name: Install build dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          brew update
+          brew install ldid || true
+          rustup target add aarch64-apple-ios
+
+      - name: Make scripts executable
+        shell: bash
+        run: |
+          set -euxo pipefail
+          chmod +x tools/development/*.sh
+          chmod +x tools/release/*.sh
+
+      - name: Update Gecko source
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+          ./tools/development/update-gecko.sh
+
+      - name: Apply Gecko patches
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+          ./tools/development/apply-patches.sh
+
+      - name: Build idevice FFI
+        shell: zsh {0}
+        run: |
+          set -euxo pipefail
+          ./tools/development/build-idevice.sh
+
+      - name: Build Gecko
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ./tools/development/build-gecko.sh
+
+      - name: Disable Xcode code signing for archive
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          p = Path("tools/release/build-app.sh")
+          s = p.read_text()
+
+          old = '-configuration Release -xcconfig "$DIST_DIR/Reynard.xcconfig"'
+          new = '-configuration Release -xcconfig "$DIST_DIR/Reynard.xcconfig" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" DEVELOPMENT_TEAM="" PROVISIONING_PROFILE_SPECIFIER=""'
+
+          if old not in s:
+              raise SystemExit("Expected xcodebuild argument string not found in tools/release/build-app.sh")
+
+          p.write_text(s.replace(old, new))
+          PY
+
+      - name: Build Reynard app archive
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ./tools/release/build-app.sh
+
+      - name: Create IPA
+        shell: bash
+        run: |
+          set -euxo pipefail
+          ./tools/release/create-ipa.sh || test -f dist/Reynard.ipa
+
+      - name: Verify IPA
+        shell: bash
+        run: |
+          set -euxo pipefail
+          test -f dist/Reynard.ipa
+          ls -lah dist/Reynard.ipa
+          shasum -a 256 dist/Reynard.ipa
+          unzip -l dist/Reynard.ipa | grep -E 'Payload/Reynard.app/(Reynard|PlugIns/Reynard Helper.appex|PlugIns/OpenIn.appex)' || true
+
+      - name: Upload Reynard IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: Reynard-latest-main-ipa
+          path: dist/Reynard.ipa
+          retention-days: 14
+
+      - name: Upload logs and dist for debugging
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: Reynard-build-debug
+          path: |
+            dist
+            engine/release.txt
+            browser/Configuration/Reynard.xcconfig
+          retention-days: 7

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -13,6 +13,11 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 360
 
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      MOZBUILD_STATE_PATH: /Users/runner/.mozbuild
+      MOZCONFIG: /Users/runner/work/reynard-browser/reynard-browser/engine/firefox/.mozconfig
+
     steps:
       - name: Checkout Reynard
         uses: actions/checkout@v4
@@ -34,9 +39,13 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
-          brew update
-          brew install ldid || true
+          brew list ldid >/dev/null 2>&1 || brew install ldid
+          brew list llvm >/dev/null 2>&1 || brew install llvm
           rustup target add aarch64-apple-ios
+          echo "/opt/homebrew/opt/llvm/bin" >> "$GITHUB_PATH"
+          /opt/homebrew/opt/llvm/bin/clang --version
+          /opt/homebrew/opt/llvm/bin/ld64.lld --version || true
+          /opt/homebrew/opt/llvm/bin/ld.lld --version || true
 
       - name: Make scripts executable
         shell: bash
@@ -63,8 +72,42 @@ jobs:
           set -euxo pipefail
           ./tools/development/build-idevice.sh
 
+      - name: Force Gecko to use Homebrew LLVM/lld
+        shell: bash
+        run: |
+          set -euxo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          p = Path("tools/development/build-gecko.sh")
+          s = p.read_text()
+
+          needle = 'echo "ac_add_options --target=$TARGET"\n'
+          insert = '''echo "ac_add_options --target=$TARGET"
+            echo "CC=/opt/homebrew/opt/llvm/bin/clang"
+            echo "CXX=/opt/homebrew/opt/llvm/bin/clang++"
+            echo "HOST_CC=/opt/homebrew/opt/llvm/bin/clang"
+            echo "HOST_CXX=/opt/homebrew/opt/llvm/bin/clang++"
+            echo "ac_add_options --enable-linker=lld"
+          '''
+
+          if needle not in s:
+              raise SystemExit("Expected target line not found in tools/development/build-gecko.sh")
+
+          p.write_text(s.replace(needle, insert, 1))
+          PY
+
+          echo "Patched build-gecko.sh:"
+          sed -n '1,120p' tools/development/build-gecko.sh
+
       - name: Build Gecko
         shell: bash
+        env:
+          PATH: /opt/homebrew/opt/llvm/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+          CC: /opt/homebrew/opt/llvm/bin/clang
+          CXX: /opt/homebrew/opt/llvm/bin/clang++
+          HOST_CC: /opt/homebrew/opt/llvm/bin/clang
+          HOST_CXX: /opt/homebrew/opt/llvm/bin/clang++
         run: |
           set -euxo pipefail
           ./tools/development/build-gecko.sh
@@ -85,7 +128,7 @@ jobs:
           if old not in s:
               raise SystemExit("Expected xcodebuild argument string not found in tools/release/build-app.sh")
 
-          p.write_text(s.replace(old, new))
+          p.write_text(s.replace(old, new, 1))
           PY
 
       - name: Build Reynard app archive
@@ -124,5 +167,8 @@ jobs:
           path: |
             dist
             engine/release.txt
+            engine/firefox/.mozconfig
+            engine/firefox/config.log
+            engine/firefox/obj-aarch64-apple-ios/.mozbuild/logs
             browser/Configuration/Reynard.xcconfig
           retention-days: 7

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -42,6 +42,7 @@ jobs:
         shell: bash
         run: |
           set -euxo pipefail
+
           brew list ldid >/dev/null 2>&1 || brew install ldid
           brew list cbindgen >/dev/null 2>&1 || brew install cbindgen
           brew list llvm >/dev/null 2>&1 || brew install llvm
@@ -49,14 +50,45 @@ jobs:
 
           rustup target add aarch64-apple-ios
 
+          WASI_WRAPPER_DIR="$RUNNER_TEMP/wasi-bin"
+          mkdir -p "$WASI_WRAPPER_DIR"
+
+          cat > "$WASI_WRAPPER_DIR/clang" <<'SH'
+          #!/usr/bin/env bash
+          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+          exec /opt/homebrew/opt/llvm/bin/clang "$@"
+          SH
+
+          cat > "$WASI_WRAPPER_DIR/clang++" <<'SH'
+          #!/usr/bin/env bash
+          export PATH="/opt/homebrew/opt/llvm/bin:$PATH"
+          exec /opt/homebrew/opt/llvm/bin/clang++ "$@"
+          SH
+
+          chmod +x "$WASI_WRAPPER_DIR/clang" "$WASI_WRAPPER_DIR/clang++"
+
           echo "CBINDGEN=/opt/homebrew/bin/cbindgen" >> "$GITHUB_ENV"
-          echo "WASM_CC=/opt/homebrew/opt/llvm/bin/clang" >> "$GITHUB_ENV"
-          echo "WASM_CXX=/opt/homebrew/opt/llvm/bin/clang++" >> "$GITHUB_ENV"
+          echo "WASM_CC=$WASI_WRAPPER_DIR/clang" >> "$GITHUB_ENV"
+          echo "WASM_CXX=$WASI_WRAPPER_DIR/clang++" >> "$GITHUB_ENV"
 
           /opt/homebrew/bin/cbindgen --version
           /opt/homebrew/opt/llvm/bin/clang --version
-          /opt/homebrew/opt/llvm/bin/clang --target=wasm32-wasi -c -x c /dev/null -o /tmp/wasm-test.o
-          ls -lah /tmp/wasm-test.o
+          /opt/homebrew/opt/llvm/bin/wasm-ld --version
+          test -d /opt/homebrew/share/wasi-sysroot
+          ls -lah /opt/homebrew/share/wasi-sysroot
+
+          cat > /tmp/wasm-test.c <<'C'
+          int main(void) { return 0; }
+          C
+
+          PATH="/opt/homebrew/opt/llvm/bin:$PATH" \
+            /opt/homebrew/opt/llvm/bin/clang \
+            --target=wasm32-unknown-wasi \
+            --sysroot=/opt/homebrew/share/wasi-sysroot \
+            /tmp/wasm-test.c \
+            -o /tmp/wasm-test.wasm
+
+          ls -lah /tmp/wasm-test.wasm
 
       - name: Make scripts executable
         shell: bash
@@ -146,7 +178,7 @@ jobs:
       - name: Build Gecko
         shell: bash
         env:
-          PATH: /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+          PATH: /opt/homebrew/opt/llvm/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
           CC: /usr/bin/clang
           CXX: /usr/bin/clang++
           HOST_CC: /usr/bin/clang

--- a/.github/workflows/build-latest-reynard-ipa.yml
+++ b/.github/workflows/build-latest-reynard-ipa.yml
@@ -77,9 +77,9 @@ jobs:
 
           python3 - <<'PY'
           from pathlib import Path
-          import re
 
-          # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64.
+          # 1) Make Reynard's generated Gecko mozconfig explicitly request ld64
+          # for the iOS target linker.
           p = Path("tools/development/build-gecko.sh")
           s = p.read_text()
 
@@ -92,30 +92,34 @@ jobs:
               s = s.replace(target_line, target_line + "\n" + ld64_line, 1)
               p.write_text(s)
 
-          # 2) Patch Firefox linker detection while preserving real indentation.
+          # 2) Patch Firefox linker detection for both:
+          #    - explicit target linker: linker == "ld64"
+          #    - implicit host linker fallback: linker is None
+          #
+          # Do NOT accept linker == "lld" here. The host probe tries lld first,
+          # and only the no-explicit-linker fallback should be treated as Xcode ld64.
           q = Path("engine/firefox/build/moz.configure/toolchain.configure")
           t = q.read_text()
 
-          pattern = r'^(?P<indent>[ \t]*)if retcode == 1 and "Logging ld64 options" in stderr:\n(?P=indent)[ \t]+kind = "ld64"'
-          m = re.search(pattern, t, flags=re.MULTILINE)
+          marker = 'target.kernel == "Darwin" and linker in (None, "ld64") and retcode != 0'
+          if marker not in t:
+              lines = t.splitlines()
+              for i, line in enumerate(lines):
+                  stripped = line.lstrip()
+                  indent = line[: len(line) - len(stripped)]
 
-          if not m:
-              raise SystemExit("Could not find exact ld64 detection block with indentation")
+                  if stripped == 'if retcode == 1 and "Logging ld64 options" in stderr:':
+                      child = indent + "    "
+                      lines[i] = f'{indent}if {marker}:'
+                      lines.insert(i + 1, f'{child}kind = "ld64"')
+                      lines.insert(i + 2, f'{indent}elif retcode == 1 and "Logging ld64 options" in stderr:')
+                      break
+              else:
+                  raise SystemExit("Could not find ld64 detection anchor in Firefox toolchain.configure")
 
-          indent = m.group("indent")
-          child = indent + "    "
+              q.write_text("\n".join(lines) + "\n")
 
-          replacement = (
-              f'{indent}if linker == "ld64" and target.kernel == "Darwin" and retcode != 0:\n'
-              f'{child}kind = "ld64"\n'
-              f'{indent}elif retcode == 1 and "Logging ld64 options" in stderr:\n'
-              f'{child}kind = "ld64"'
-          )
-
-          t = t[:m.start()] + replacement + t[m.end():]
-          q.write_text(t)
-
-          # 3) Validate patched Python syntax before wasting another run.
+          # 3) Validate patched Python syntax before running configure.
           compile(q.read_text(), str(q), "exec")
           PY
 
@@ -123,7 +127,7 @@ jobs:
           sed -n '1,100p' tools/development/build-gecko.sh
 
           echo "Patched linker detection context:"
-          grep -n -A10 -B6 'Logging ld64 options' engine/firefox/build/moz.configure/toolchain.configure
+          grep -n -A12 -B6 'Logging ld64 options' engine/firefox/build/moz.configure/toolchain.configure
 
       - name: Build Gecko
         shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# AGENTS.md
+
+## Mission
+
+You are operating in the root of the `lowestprime/reynard-browser` fork. Your job is to act as an autonomous senior build/release engineer and iOS browser engineer for Reynard. Deliver working code and a downloadable IPA artifact, not just analysis.
+
+The primary user goal is to build a latest-main Reynard IPA that includes post-0.4.0 upstream fixes, especially iOS 26.6 / iPhone 15 Pro Max JIT/TXM-related fixes, and then add a robust Page Zoom feature comparable to or better than iOS Safari.
+
+## Repository map
+
+Important root-level paths:
+
+* `.github/workflows/build-latest-reynard-ipa.yml` — custom GitHub Actions workflow for building the latest Reynard IPA.
+* `tools/development/update-gecko.sh` — checks out the Firefox source tag from `engine/release.txt`.
+* `tools/development/apply-patches.sh` — applies Reynard’s Firefox patches.
+* `tools/development/build-idevice.sh` — builds the idevice FFI library used by JIT/pairing support.
+* `tools/development/build-gecko.sh` — generates Gecko `.mozconfig` and runs `./mach build`.
+* `tools/release/build-app.sh` — archives the iOS app with Xcode.
+* `tools/release/create-ipa.sh` — creates `dist/Reynard.ipa`.
+* `browser/Reynard` — native iOS app source.
+* `browser/GeckoView` — iOS GeckoView wrapper code.
+* `browser/Configuration/Reynard.xcconfig` — app build configuration.
+* `engine/release.txt` — Firefox source release tag.
+* `engine/firefox` — large Firefox submodule; treat as third-party generated/checked-out source.
+* `patches/` — durable Reynard patches applied to Firefox source.
+
+## Critical constraints
+
+* Do not start from or treat `engine/firefox` as the project root.
+* Do not directly commit arbitrary edits inside `engine/firefox`; the workflow checks out Firefox source and applies patches. Durable Firefox-source changes must be represented as root-level workflow edits, `tools/` edits, or patch files under `patches/`.
+* Do not delete user work.
+* Do not run destructive git commands such as `git reset --hard`, `git clean -fdx`, or `git checkout -- .` unless the user explicitly approves.
+* Do not replace Apple/Xcode clang for iOS/macOS compilation unless a log proves it is necessary. The working build direction is Apple clang for host/target plus Homebrew LLVM/LLD only for WASM/WASI.
+* Do not trust or recommend random third-party IPAs as the final success path unless the artifact, source commit, and provenance are verifiably better than building from this fork.
+* Do not stop after writing a plan. Plans guide implementation; the deliverable is a working GitHub Actions artifact.
+
+## Known current build state
+
+The workflow has already advanced through these prior blockers:
+
+* GitHub Actions checkout works.
+* Firefox 152 source checkout works.
+* Reynard patches apply.
+* idevice FFI builds.
+* Gecko target linker has been patched to identify Xcode `ld64`.
+* Gecko host linker has been patched to identify Xcode `ld64`.
+* `cbindgen` is installed and found.
+* WASM compiler setup advanced far enough to expose a separate linker problem.
+
+The latest known failure is in the `Install build dependencies` step after adding a WASI wrapper. The workflow hard-coded `/opt/homebrew/opt/llvm/bin/wasm-ld`, but Homebrew’s LLVM install on the runner does not provide `wasm-ld` there. The next likely fix is to explicitly install Homebrew `lld`, prepend `/opt/homebrew/opt/lld/bin` before `/opt/homebrew/opt/llvm/bin` for WASM-only use, and find `wasm-ld` with `command -v wasm-ld` rather than hard-coding the LLVM path.
+
+## Required build strategy
+
+Use this order:
+
+1. Inspect current `git status`, latest commit, workflow file, and latest failed GitHub Actions log.
+2. Fix the immediate build failure with the smallest targeted change.
+3. Commit and push the fix.
+4. Trigger the GitHub Actions workflow.
+5. Watch the run.
+6. If it fails, retrieve the failed log and debug artifact.
+7. Parse the exact failing lines.
+8. Patch the root cause.
+9. Repeat until `Reynard-latest-main-ipa` is uploaded and `dist/Reynard.ipa` exists.
+10. Download and verify the IPA artifact before declaring success.
+
+Use these commands when appropriate:
+
+```powershell
+gh workflow run "Build Latest Reynard IPA" --repo lowestprime/reynard-browser --ref main
+gh run list --repo lowestprime/reynard-browser --workflow "Build Latest Reynard IPA" --limit 5
+gh run watch <RUN_ID> --repo lowestprime/reynard-browser
+gh run view <RUN_ID> --repo lowestprime/reynard-browser --log-failed
+gh run download <RUN_ID> --repo lowestprime/reynard-browser --name Reynard-build-debug --dir "$env:USERPROFILE\Desktop\reynard-build-debug-latest"
+gh run download <RUN_ID> --repo lowestprime/reynard-browser --name Reynard-latest-main-ipa --dir "$env:USERPROFILE\Downloads\Reynard-latest-main"
+```
+
+## Immediate build hypothesis to test first
+
+Patch `.github/workflows/build-latest-reynard-ipa.yml` so the dependency step:
+
+* installs `lld` explicitly,
+* does not call `/opt/homebrew/opt/llvm/bin/wasm-ld` directly,
+* uses `command -v wasm-ld`,
+* prepends `/opt/homebrew/opt/lld/bin:/opt/homebrew/opt/llvm/bin` for WASM-only wrapper commands,
+* verifies a real WASM link with `--target=wasm32-unknown-wasi` and `--sysroot=/opt/homebrew/share/wasi-sysroot`.
+
+If the WASI link still fails after explicit `lld`, perform one further targeted attempt. If that still fails, use the Gecko fallback `--without-wasm-sandboxed-libraries` only as a documented build-product-first fallback, and record the decision in the ExecPlan.
+
+## Page Zoom feature requirements
+
+After the latest-main IPA pipeline is green, implement a Page Zoom feature in Reynard with these properties:
+
+* User-visible Page Zoom controls comparable to or better than iOS Safari.
+* Supports zoom out, zoom in, reset, and a displayed current percentage.
+* Provides sensible zoom levels, ideally including 50%, 75%, 85%, 100%, 115%, 125%, 150%, 175%, 200%, 250%, and 300%, unless existing architecture suggests a better set.
+* Persists zoom per-site/domain when feasible.
+* Provides a default/global zoom setting when feasible.
+* Applies to the active tab without requiring app restart.
+* Does not break JIT, browsing, extension behavior, app startup, or existing navigation UI.
+* Uses existing Reynard/GeckoView architecture and preferences wherever possible rather than adding a brittle CSS-only hack.
+* Includes a conservative fallback path if true Gecko page zoom is unavailable in the current iOS GeckoView layer.
+* Verifies with build-level checks and, where possible, small unit-level or logic-level tests.
+
+Search the codebase first. Identify how tabs, sessions, settings, menus, and Gecko preferences are represented before editing. Do not assume WebKit APIs exist; Reynard is Gecko-based.
+
+## Verification standards
+
+Done means all of the following are true:
+
+* Latest upstream main is integrated or the fork is explicitly synchronized with `minh-ton/reynard-browser@main`.
+* Workflow runs on GitHub Actions without failure.
+* `Reynard-latest-main-ipa` artifact exists.
+* Downloaded artifact contains `Reynard.ipa`.
+* `Reynard.ipa` contains the main app and required extensions.
+* Build identity in the workflow logs shows a post-0.4.0 commit/build, not only `63836c3`.
+* Page Zoom feature is implemented, discoverable, and documented.
+* The final response identifies the exact GitHub Actions run ID, commit SHA, artifact name, and remaining risks.
+
+## Reporting format
+
+At the end of work, report:
+
+* Final commit SHA.
+* Successful GitHub Actions run ID and URL.
+* Artifact name and local downloaded path if downloaded.
+* Summary of workflow fixes.
+* Summary of Page Zoom implementation.
+* Tests/builds run.
+* Any remaining risks, especially around iOS 26.6 JIT behavior that cannot be verified without the physical iPhone.

--- a/PLANS.md
+++ b/PLANS.md
@@ -1,0 +1,115 @@
+# PLANS.md
+
+This repository uses execution plans for long-running Codex work. An execution plan is a living, self-contained implementation document that allows a future agent or human to resume the task without relying on hidden context.
+
+Use an ExecPlan for any task that includes one or more of the following:
+
+* GitHub Actions build repair.
+* Multi-step debugging.
+* iOS/Gecko/Reynard feature work.
+* JIT, TXM, DDI, pairing, SideStore, or LocalDevVPN work.
+* Page Zoom implementation.
+* Any task expected to require more than one commit or more than one build/test cycle.
+
+## Non-negotiable requirements
+
+Every ExecPlan must:
+
+* Be self-contained.
+* State the purpose and user-visible outcome.
+* Define success criteria before implementation.
+* Track progress continuously.
+* Record surprises and discoveries.
+* Record decisions and why they were made.
+* Include exact commands run and relevant outputs.
+* Include links or identifiers for GitHub Actions runs.
+* Distinguish verified facts from hypotheses.
+* Never leave `in_progress` work unaccounted for at a stopping point.
+* End with a clear outcome and retrospective.
+
+## Required ExecPlan skeleton
+
+Create task-specific plans under `.agent/execplans/`.
+
+Use this filename pattern:
+
+```text
+.agent/execplans/YYYYMMDD_short-task-name.md
+```
+
+Use this template:
+
+```md
+# <Short task title>
+
+This ExecPlan follows the repository root `PLANS.md`. It must remain current as work proceeds.
+
+## Purpose / Big Picture
+
+Explain what user-visible outcome this work enables and why it matters.
+
+## Success Criteria
+
+- [ ] Criterion 1.
+- [ ] Criterion 2.
+- [ ] Criterion 3.
+
+## Current State
+
+Describe the current repo state, branch, important files, latest known failure or target behavior, and exact evidence. Include run IDs, commit SHAs, paths, and artifact names where relevant.
+
+## Constraints
+
+List hard constraints, do-not rules, platform limitations, and assumptions.
+
+## Progress
+
+- [ ] Initial context inspected.
+- [ ] Plan created.
+- [ ] First implementation step completed.
+- [ ] Verification run completed.
+- [ ] Final outcome recorded.
+
+Update this section at every meaningful stopping point.
+
+## Surprises & Discoveries
+
+Record unexpected findings with short evidence snippets. Include exact error lines, command outputs, or file paths when useful.
+
+## Decision Log
+
+- Decision:
+  - Reason:
+  - Evidence:
+  - Consequence:
+
+## Plan of Work
+
+Describe the implementation sequence in prose. Name exact files and expected changes. Keep it concrete.
+
+## Concrete Steps
+
+List exact commands and expected observations.
+
+## Validation
+
+State exactly how success will be verified. Include local checks, GitHub Actions checks, artifact inspection, and manual device checks where applicable.
+
+## Recovery / Fallbacks
+
+Document what to do if each likely failure occurs. Include when to use a fallback versus when to continue repairing the primary path.
+
+## Outcomes & Retrospective
+
+Fill this in at completion or stopping point:
+
+- What changed:
+- What passed:
+- What failed or remains unknown:
+- Artifact/run/commit identifiers:
+- Recommended next action:
+```
+
+## Working rule
+
+When implementing an ExecPlan, do not ask the user for “next steps” after each milestone. Continue to the next milestone autonomously until the task is complete, blocked by a real external limitation, or the available run time is exhausted. If blocked, record the blocker, evidence, and the smallest precise question needed to proceed.

--- a/browser/GeckoView/Session/GeckoSession.swift
+++ b/browser/GeckoView/Session/GeckoSession.swift
@@ -17,17 +17,20 @@ public struct GeckoSessionSettings: Equatable {
     public static let `default` = GeckoSessionSettings(
         userAgentOverride: nil,
         userAgentMode: 0,
-        viewportMode: 0
+        viewportMode: 0,
+        pageZoom: 1.0
     )
     
     public let userAgentOverride: String?
     public let userAgentMode: Int
     public let viewportMode: Int
+    public let pageZoom: Double
     
-    public init(userAgentOverride: String?, userAgentMode: Int, viewportMode: Int) {
+    public init(userAgentOverride: String?, userAgentMode: Int, viewportMode: Int, pageZoom: Double) {
         self.userAgentOverride = userAgentOverride
         self.userAgentMode = userAgentMode
         self.viewportMode = viewportMode
+        self.pageZoom = pageZoom
     }
 }
 
@@ -61,6 +64,7 @@ public class GeckoSession {
                 "userAgentOverride": uaValue,
                 "userAgentMode": settings.userAgentMode,
                 "viewportMode": settings.viewportMode,
+                "pageZoom": settings.pageZoom,
             ])
     }
     
@@ -161,6 +165,7 @@ public class GeckoSession {
             "userAgentMode": settings.userAgentMode,
             "userAgentOverride": settings.userAgentOverride,
             "viewportMode": settings.viewportMode,
+            "pageZoom": settings.pageZoom,
             "displayMode": 0,
             "suspendMediaWhenInactive": false,
             "allowJavascript": true,

--- a/browser/Reynard/Client/Extensions/Notifications.swift
+++ b/browser/Reynard/Client/Extensions/Notifications.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Notification.Name {
     static let addressBarPositionDidChange = Notification.Name("Chrome.AddressBarPositionDidChange")
+    static let appearancePreferencesDidChange = Notification.Name("Appearance.PreferencesDidChange")
     static let landscapeTabBarDidChange = Notification.Name("Chrome.LandscapeTabBarDidChange")
     static let pageZoomPreferencesDidChange = Notification.Name("Settings.PageZoomPreferencesDidChange")
     static let appUpdateAvailable = Notification.Name("Settings.AppUpdateAvailable")

--- a/browser/Reynard/Client/Extensions/Notifications.swift
+++ b/browser/Reynard/Client/Extensions/Notifications.swift
@@ -10,6 +10,7 @@ import Foundation
 extension Notification.Name {
     static let addressBarPositionDidChange = Notification.Name("Chrome.AddressBarPositionDidChange")
     static let landscapeTabBarDidChange = Notification.Name("Chrome.LandscapeTabBarDidChange")
+    static let pageZoomPreferencesDidChange = Notification.Name("Settings.PageZoomPreferencesDidChange")
     static let appUpdateAvailable = Notification.Name("Settings.AppUpdateAvailable")
     static let bookmarkStoreDidChange = Notification.Name("BookmarkStore.DidChange")
     static let downloadStoreDidChange = Notification.Name("DownloadStore.DidChange")

--- a/browser/Reynard/Client/Interface/Appearance/BrowserAppearance.swift
+++ b/browser/Reynard/Client/Interface/Appearance/BrowserAppearance.swift
@@ -1,0 +1,120 @@
+//
+//  BrowserAppearance.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import UIKit
+
+enum BrowserThemeMode: String, CaseIterable {
+    case system
+    case light
+    case dark
+    case oledBlack
+
+    var displayName: String {
+        switch self {
+        case .system:
+            return "System"
+        case .light:
+            return "Light"
+        case .dark:
+            return "Dark"
+        case .oledBlack:
+            return "OLED Black"
+        }
+    }
+
+    var overrideStyle: UIUserInterfaceStyle {
+        switch self {
+        case .system:
+            return .unspecified
+        case .light:
+            return .light
+        case .dark, .oledBlack:
+            return .dark
+        }
+    }
+}
+
+enum BrowserAccentColor: String, CaseIterable {
+    case highContrast
+    case blue
+    case orange
+    case green
+    case purple
+
+    var displayName: String {
+        switch self {
+        case .highContrast:
+            return "High Contrast"
+        case .blue:
+            return "Blue"
+        case .orange:
+            return "Orange"
+        case .green:
+            return "Green"
+        case .purple:
+            return "Purple"
+        }
+    }
+
+    var color: UIColor {
+        switch self {
+        case .highContrast:
+            return .label
+        case .blue:
+            return .systemBlue
+        case .orange:
+            return .systemOrange
+        case .green:
+            return .systemGreen
+        case .purple:
+            return .systemPurple
+        }
+    }
+}
+
+enum BrowserAppearance {
+    static func apply(to window: UIWindow?) {
+        guard let window else { return }
+        window.overrideUserInterfaceStyle = Prefs.AppearanceSettings.themeMode.overrideStyle
+        window.tintColor = accentColor
+        window.rootViewController?.view.tintColor = accentColor
+    }
+
+    static var accentColor: UIColor {
+        Prefs.AppearanceSettings.accentColor.color
+    }
+
+    static var backgroundColor: UIColor {
+        dynamicColor(oled: .black, standard: .systemBackground)
+    }
+
+    static var groupedBackgroundColor: UIColor {
+        dynamicColor(oled: .black, standard: .systemGroupedBackground)
+    }
+
+    static var toolbarBackgroundColor: UIColor {
+        dynamicColor(oled: .black, standard: .systemGray6)
+    }
+
+    static var surfaceColor: UIColor {
+        dynamicColor(oled: UIColor(white: 0.04, alpha: 1), standard: .systemBackground)
+    }
+
+    static var secondarySurfaceColor: UIColor {
+        dynamicColor(oled: UIColor(white: 0.08, alpha: 1), standard: .secondarySystemBackground)
+    }
+
+    private static func dynamicColor(oled: UIColor, standard: UIColor) -> UIColor {
+        UIColor { traitCollection in
+            guard Prefs.AppearanceSettings.themeMode == .oledBlack,
+                  traitCollection.userInterfaceStyle == .dark else {
+                return standard
+            }
+            return oled
+        }
+    }
+}

--- a/browser/Reynard/Client/Interface/Appearance/BrowserAppearance.swift
+++ b/browser/Reynard/Client/Interface/Appearance/BrowserAppearance.swift
@@ -44,6 +44,14 @@ enum BrowserAccentColor: String, CaseIterable {
     case orange
     case green
     case purple
+    case custom
+
+    static let defaultCustomHex = "#007AFF"
+    private static let minimumCustomContrastRatio: CGFloat = 1.35
+
+    static var presetCases: [BrowserAccentColor] {
+        [.highContrast, .blue, .orange, .green, .purple]
+    }
 
     var displayName: String {
         switch self {
@@ -57,6 +65,8 @@ enum BrowserAccentColor: String, CaseIterable {
             return "Green"
         case .purple:
             return "Purple"
+        case .custom:
+            return "Custom"
         }
     }
 
@@ -72,7 +82,88 @@ enum BrowserAccentColor: String, CaseIterable {
             return .systemGreen
         case .purple:
             return .systemPurple
+        case .custom:
+            return Prefs.AppearanceSettings.customAccentColor
         }
+    }
+
+    static func normalizedCustomHex(_ hexString: String) -> String? {
+        UIColor(hexString: hexString)?.toHexString().uppercased()
+    }
+
+    static func validationMessage(forCustomHex hexString: String) -> String? {
+        guard let color = UIColor(hexString: hexString) else {
+            return "Enter a 6-digit hex color such as #007AFF."
+        }
+
+        return validationMessage(forCustomColor: color)
+    }
+
+    static func validationMessage(forCustomColor color: UIColor) -> String? {
+        guard let components = color.rgbaComponents(in: .current) else {
+            return "Choose a standard RGB color."
+        }
+
+        guard components.alpha >= 0.95 else {
+            return "Accent colors must be opaque."
+        }
+
+        let backgrounds: [(String, UIColor, UITraitCollection)] = [
+            ("Light", .systemBackground, UITraitCollection(userInterfaceStyle: .light)),
+            ("Dark", .systemBackground, UITraitCollection(userInterfaceStyle: .dark)),
+            ("OLED Black", .black, UITraitCollection(userInterfaceStyle: .dark)),
+        ]
+
+        for (name, background, traitCollection) in backgrounds {
+            guard let contrast = contrastRatio(
+                foreground: color,
+                background: background,
+                traitCollection: traitCollection
+            ) else {
+                continue
+            }
+
+            if contrast < minimumCustomContrastRatio {
+                return "Choose a color with more contrast against \(name) backgrounds, or use High Contrast."
+            }
+        }
+
+        return nil
+    }
+
+    private static func contrastRatio(
+        foreground: UIColor,
+        background: UIColor,
+        traitCollection: UITraitCollection
+    ) -> CGFloat? {
+        guard let foregroundComponents = foreground.rgbaComponents(in: traitCollection),
+              let backgroundComponents = background.rgbaComponents(in: traitCollection) else {
+            return nil
+        }
+
+        let foregroundLuminance = relativeLuminance(
+            red: foregroundComponents.red,
+            green: foregroundComponents.green,
+            blue: foregroundComponents.blue
+        )
+        let backgroundLuminance = relativeLuminance(
+            red: backgroundComponents.red,
+            green: backgroundComponents.green,
+            blue: backgroundComponents.blue
+        )
+        let lighter = max(foregroundLuminance, backgroundLuminance)
+        let darker = min(foregroundLuminance, backgroundLuminance)
+        return (lighter + 0.05) / (darker + 0.05)
+    }
+
+    private static func relativeLuminance(red: CGFloat, green: CGFloat, blue: CGFloat) -> CGFloat {
+        func component(_ value: CGFloat) -> CGFloat {
+            value <= 0.03928
+            ? value / 12.92
+            : pow((value + 0.055) / 1.055, 2.4)
+        }
+
+        return 0.2126 * component(red) + 0.7152 * component(green) + 0.0722 * component(blue)
     }
 }
 
@@ -116,5 +207,26 @@ enum BrowserAppearance {
             }
             return oled
         }
+    }
+}
+
+private extension UIColor {
+    func rgbaComponents(in traitCollection: UITraitCollection) -> (
+        red: CGFloat,
+        green: CGFloat,
+        blue: CGFloat,
+        alpha: CGFloat
+    )? {
+        let color = resolvedColor(with: traitCollection)
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+
+        guard color.getRed(&red, green: &green, blue: &blue, alpha: &alpha) else {
+            return nil
+        }
+
+        return (red, green, blue, alpha)
     }
 }

--- a/browser/Reynard/Client/Interface/BrowserViewController+AddressBar.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController+AddressBar.swift
@@ -74,25 +74,28 @@ extension BrowserViewController: AddressBarDelegate, AddressBarGestureDelegate {
         presentWebsiteSettings()
     }
 
-    func addressBarDidRequestPageZoomOut(_ addressBar: AddressBar) {
-        changePageZoom { store, url in
-            store.lowerPercent(for: url)
-        }
-    }
-
-    func addressBarDidRequestPageZoomIn(_ addressBar: AddressBar) {
-        changePageZoom { store, url in
-            store.higherPercent(for: url)
-        }
-    }
-
-    func addressBarDidRequestPageZoomReset(_ addressBar: AddressBar) {
+    func addressBarDidRequestPageZoomControls(_ addressBar: AddressBar) {
         guard let selectedTab = tabManager.selectedTab,
               let url = selectedTab.url else {
             return
         }
 
-        PageZoomStore.shared.resetOverride(for: url)
+        let controller = PageZoomControlsViewController(
+            urlString: url,
+            pageTitle: selectedTab.title
+        )
+        controller.onChange = { [weak self] in
+            self?.applyPageZoomToSelectedTab()
+            self?.refreshAddressBar()
+        }
+
+        let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.modalPresentationStyle = .pageSheet
+        if #available(iOS 15.0, *) {
+            navigationController.sheetPresentationController?.detents = [.medium()]
+            navigationController.sheetPresentationController?.prefersGrabberVisible = true
+        }
+        present(navigationController, animated: true)
     }
 
     func addressBar(_ addressBar: AddressBar, didRequestBookmarkInFavorites favorites: Bool) {
@@ -209,16 +212,6 @@ extension BrowserViewController: AddressBarDelegate, AddressBarGestureDelegate {
             canZoomOut: PageZoomLevel.lowerPercent(than: percent) != nil,
             canZoomIn: PageZoomLevel.higherPercent(than: percent) != nil
         )
-    }
-
-    private func changePageZoom(_ nextPercent: (PageZoomStore, String) -> Int?) {
-        guard let selectedTab = tabManager.selectedTab,
-              let url = selectedTab.url,
-              let percent = nextPercent(PageZoomStore.shared, url) else {
-            return
-        }
-
-        PageZoomStore.shared.setOverridePercent(percent, for: url)
     }
 
     func applyPageZoomToSelectedTab() {

--- a/browser/Reynard/Client/Interface/BrowserViewController+AddressBar.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController+AddressBar.swift
@@ -38,7 +38,8 @@ extension BrowserViewController: AddressBarDelegate, AddressBarGestureDelegate {
         }
         browserChrome.updateAddressBarMenu(
             url: selectedURL,
-            usesDesktopWebsite: usesDesktopWebsite
+            usesDesktopWebsite: usesDesktopWebsite,
+            pageZoom: selectedTab.flatMap(pageZoomMenuState)
         )
     }
     
@@ -72,7 +73,28 @@ extension BrowserViewController: AddressBarDelegate, AddressBarGestureDelegate {
     func addressBarDidRequestWebsiteSettings(_ addressBar: AddressBar) {
         presentWebsiteSettings()
     }
-    
+
+    func addressBarDidRequestPageZoomOut(_ addressBar: AddressBar) {
+        changePageZoom { store, url in
+            store.lowerPercent(for: url)
+        }
+    }
+
+    func addressBarDidRequestPageZoomIn(_ addressBar: AddressBar) {
+        changePageZoom { store, url in
+            store.higherPercent(for: url)
+        }
+    }
+
+    func addressBarDidRequestPageZoomReset(_ addressBar: AddressBar) {
+        guard let selectedTab = tabManager.selectedTab,
+              let url = selectedTab.url else {
+            return
+        }
+
+        PageZoomStore.shared.resetOverride(for: url)
+    }
+
     func addressBar(_ addressBar: AddressBar, didRequestBookmarkInFavorites favorites: Bool) {
         presentBookmarkEditor(addToFavorites: favorites)
     }
@@ -170,5 +192,45 @@ extension BrowserViewController: AddressBarDelegate, AddressBarGestureDelegate {
         let navigationController = UINavigationController(rootViewController: bookmarkController)
         navigationController.modalPresentationStyle = .pageSheet
         present(navigationController, animated: true)
+    }
+
+    private func pageZoomMenuState(for tab: Tab) -> AddressBarMenu.PageZoomState? {
+        guard let url = tab.url,
+              DomainMatcher.host(from: url) != nil else {
+            return nil
+        }
+
+        let store = PageZoomStore.shared
+        let percent = store.zoomPercent(for: url)
+        return AddressBarMenu.PageZoomState(
+            percent: percent,
+            defaultPercent: store.defaultPercent,
+            hasSiteOverride: store.hasOverride(for: url),
+            canZoomOut: PageZoomLevel.lowerPercent(than: percent) != nil,
+            canZoomIn: PageZoomLevel.higherPercent(than: percent) != nil
+        )
+    }
+
+    private func changePageZoom(_ nextPercent: (PageZoomStore, String) -> Int?) {
+        guard let selectedTab = tabManager.selectedTab,
+              let url = selectedTab.url,
+              let percent = nextPercent(PageZoomStore.shared, url) else {
+            return
+        }
+
+        PageZoomStore.shared.setOverridePercent(percent, for: url)
+    }
+
+    func applyPageZoomToSelectedTab() {
+        guard let selectedTab = tabManager.selectedTab,
+              let url = selectedTab.url else {
+            return
+        }
+
+        applyPageZoom(to: selectedTab, url: url)
+    }
+
+    private func applyPageZoom(to tab: Tab, url: String) {
+        sessionManager.updateSettings(of: tab.session, for: url, tabID: tab.id)
     }
 }

--- a/browser/Reynard/Client/Interface/BrowserViewController+TabManager.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController+TabManager.swift
@@ -58,6 +58,13 @@ extension BrowserViewController: TabManagerDelegate {
     }
     
     func tabManager(_ tabManager: TabManager, didReplaceSelectedSession previousSession: GeckoSession, with replacementSession: GeckoSession) {
+        if contentView.isDisplaying(session: previousSession)
+            || tabManager.selectedTab?.session === replacementSession {
+            contentView.setSession(replacementSession)
+            contentView.restoreInteraction(for: replacementSession)
+            updateBrowserLayout(animated: false)
+            applyPageZoomToSelectedTab()
+        }
         addonCoordinator.handleSelectedTabSessionReplacement(from: previousSession, to: replacementSession)
     }
     

--- a/browser/Reynard/Client/Interface/BrowserViewController.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController.swift
@@ -31,6 +31,7 @@ final class BrowserViewController: UIViewController {
     private var preFullscreenOrientation: UIInterfaceOrientation?
     weak var fullscreenSession: GeckoSession?
     private let allowsSidebarHosting: Bool
+    private var visibleKeyboardFrame: CGRect?
     private(set) var browserLayout = BrowserLayout.initial(
         interfaceIdiom: UIDevice.current.userInterfaceIdiom
     )
@@ -109,13 +110,14 @@ final class BrowserViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = BrowserAppearance.backgroundColor
         
         if sidebarCoordinator.installHostIfNeeded() {
             return
         }
         
         configureBrowserInterface()
+        applyBrowserAppearance()
         observeNotifications()
         contextMenuCoordinator.configure()
         downloadsCoordinator.startObservingStore()
@@ -194,6 +196,10 @@ final class BrowserViewController: UIViewController {
                 self.contentView.setTransitionTransform(.identity)
                 self.browserChrome.resetHorizontalTransition()
                 self.tabOverview.refreshForCurrentOrientation()
+                if self.visibleKeyboardFrame != nil {
+                    self.contentView.resetFocusedInputRelocation()
+                    self.visibleKeyboardFrame = nil
+                }
                 DispatchQueue.main.async {
                     guard self.isViewLoaded, self.view.window != nil else {
                         return
@@ -565,6 +571,42 @@ final class BrowserViewController: UIViewController {
             name: .pageZoomPreferencesDidChange,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appearancePreferencesDidChange),
+            name: .appearancePreferencesDidChange,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillResignActive),
+            name: UIApplication.willResignActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidEnterBackground),
+            name: UIApplication.didEnterBackgroundNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidBecomeActive),
+            name: UIApplication.didBecomeActiveNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationWillTerminate),
+            name: UIApplication.willTerminateNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(applicationDidReceiveMemoryWarning),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
     }
     
     // MARK: - Keyboard
@@ -575,10 +617,12 @@ final class BrowserViewController: UIViewController {
         }
         
         let keyboardFrame = view.convert(frameValue.cgRectValue, from: nil)
+        let keyboardIntersection = view.bounds.intersection(keyboardFrame)
         let keyboardInset = max(
             0,
-            view.bounds.maxY - keyboardFrame.minY - view.safeAreaInsets.bottom
+            keyboardIntersection.height - view.safeAreaInsets.bottom
         )
+        visibleKeyboardFrame = keyboardInset > 0 ? keyboardFrame : nil
         let animation = keyboardAnimation(from: notification)
         if !searchOverlayCoordinator.isFocused && !tabOverview.isPresented && keyboardInset > 0 {
             contentView.relocateFocusedInput(
@@ -603,6 +647,7 @@ final class BrowserViewController: UIViewController {
     
     @objc private func keyboardWillHide(_ notification: Notification) {
         let animation = keyboardAnimation(from: notification)
+        visibleKeyboardFrame = nil
         contentView.resetFocusedInputRelocation(
             animationDuration: animation.duration,
             animationOptions: animation.curve
@@ -626,6 +671,66 @@ final class BrowserViewController: UIViewController {
         UIView.animate(withDuration: animation.duration, delay: 0, options: [animation.curve]) {
             self.view.layoutIfNeeded()
         }
+    }
+
+    // MARK: - App Lifecycle
+
+    func saveBrowserStateForLifecycleEvent(_ _: String) {
+        guard isViewLoaded else {
+            return
+        }
+
+        captureThumbnailForVisibleTab(at: tabManager.selectedTabIndex)
+        tabManager.flushStateForLifecycleEvent()
+    }
+
+    func restoreBrowserStateAfterForeground() {
+        guard isViewLoaded else {
+            return
+        }
+
+        BrowserAppearance.apply(to: view.window)
+        if let session = tabManager.selectedTab?.session {
+            sessionManager.activate(session)
+        }
+        syncBrowserNavigationChrome(animated: false)
+        refreshAddressBar()
+        updateNavigationButtons()
+        applyPageZoomToSelectedTab()
+        updateBrowserLayout(animated: false)
+    }
+
+    @objc private func appearancePreferencesDidChange() {
+        applyBrowserAppearance()
+    }
+
+    @objc private func applicationWillResignActive() {
+        saveBrowserStateForLifecycleEvent("willResignActive")
+    }
+
+    @objc private func applicationDidEnterBackground() {
+        saveBrowserStateForLifecycleEvent("didEnterBackground")
+    }
+
+    @objc private func applicationDidBecomeActive() {
+        restoreBrowserStateAfterForeground()
+    }
+
+    @objc private func applicationWillTerminate() {
+        saveBrowserStateForLifecycleEvent("willTerminate")
+    }
+
+    @objc private func applicationDidReceiveMemoryWarning() {
+        saveBrowserStateForLifecycleEvent("memoryWarning")
+    }
+
+    private func applyBrowserAppearance() {
+        BrowserAppearance.apply(to: view.window)
+        view.backgroundColor = BrowserAppearance.backgroundColor
+        contentView.applyAppearance()
+        browserChrome.applyAppearance()
+        view.tintColor = BrowserAppearance.accentColor
+        setNeedsStatusBarAppearanceUpdate()
     }
     
     @objc func addressBarPositionDidChange() {

--- a/browser/Reynard/Client/Interface/BrowserViewController.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController.swift
@@ -15,14 +15,30 @@ final class BrowserViewController: UIViewController {
         static let keyboardAnimationDuration: TimeInterval = 0.25
         static let keyboardAnimationCurve: UInt = 7
     }
-    
+
     private struct KeyboardAnimation {
         let duration: TimeInterval
         let curve: UIView.AnimationOptions
     }
-    
+
+    private struct KeyboardAvoidanceState {
+        let keyboardFrame: CGRect?
+        let keyboardOverlapHeight: CGFloat
+        let pageViewportBottomInset: CGFloat
+
+        var hasKeyboardOverlap: Bool {
+            keyboardOverlapHeight > 0
+        }
+
+        static let inactive = KeyboardAvoidanceState(
+            keyboardFrame: nil,
+            keyboardOverlapHeight: 0,
+            pageViewportBottomInset: 0
+        )
+    }
+
     // MARK: - State
-    
+
     let sessionManager = SessionManager()
     lazy var tabManager: TabManager = TabManagerImplementation(
         delegate: self,
@@ -35,14 +51,14 @@ final class BrowserViewController: UIViewController {
     private(set) var browserLayout = BrowserLayout.initial(
         interfaceIdiom: UIDevice.current.userInterfaceIdiom
     )
-    
+
     // MARK: - Views And Coordinators
-    
+
     let tabBar = TabBar()
     let tabOverview = TabOverview()
     let contentView = ContentView()
     lazy var browserChrome = BrowserChrome()
-    
+
     lazy var overlayCoordinator = OverlayCoordinator(host: self)
     lazy var searchOverlayCoordinator = SearchOverlayCoordinator(
         delegate: self,
@@ -59,63 +75,63 @@ final class BrowserViewController: UIViewController {
         delegate: self,
         sessionManager: sessionManager
     )
-    
+
     private(set) var isShowingFullscreenMedia = false {
         didSet {
             setNeedsStatusBarAppearanceUpdate()
         }
     }
-    
+
     // MARK: - Lifecycle
-    
+
     override var prefersStatusBarHidden: Bool {
         return isShowingFullscreenMedia
     }
-    
+
     override var childForStatusBarHidden: UIViewController? {
         return sidebarCoordinator.statusBarController
     }
-    
+
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if isShowingFullscreenMedia && browserLayout.interfaceIdiom == .phone {
             return .landscape
         }
-        
+
         return browserLayout.interfaceIdiom == .pad ? .all : .allButUpsideDown
     }
-    
+
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         if isShowingFullscreenMedia && browserLayout.interfaceIdiom == .phone {
             return .landscapeRight
         }
-        
+
         return .portrait
     }
-    
+
     init(canHostSidebar: Bool = true) {
         self.allowsSidebarHosting = canHostSidebar
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     deinit {
         if isShowingFullscreenMedia {
             UIApplication.shared.isIdleTimerDisabled = false
         }
         NotificationCenter.default.removeObserver(self)
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = BrowserAppearance.backgroundColor
-        
+
         if sidebarCoordinator.installHostIfNeeded() {
             return
         }
-        
+
         configureBrowserInterface()
         applyBrowserAppearance()
         observeNotifications()
@@ -126,38 +142,38 @@ final class BrowserViewController: UIViewController {
         syncBrowserNavigationChrome(animated: false)
         browserChrome.syncSidebarButton(splitViewController: splitViewController)
         applyUpdateMenuButtonBadge()
-        
+
         tabManager.createInitialTab()
         refreshAddressBar()
-        
+
         Task { @MainActor [weak self] in
             guard let self else {
                 return
             }
-            
+
             await self.addonCoordinator.start()
             if let session = self.tabManager.selectedTab?.session {
                 self.sessionManager.setAddonTabActive(true, for: session)
             }
         }
-        
+
         updateBrowserLayout(animated: false)
     }
-    
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         performContentLifecycle {
             syncBrowserNavigationChrome(animated: animated)
         }
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         performContentLifecycle {
             view.endEditing(true)
         }
     }
-    
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         performContentLifecycle {
@@ -167,7 +183,7 @@ final class BrowserViewController: UIViewController {
             updateBrowserLayout(animated: false)
         }
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if sidebarCoordinator.refreshHostVisibility() {
@@ -181,7 +197,7 @@ final class BrowserViewController: UIViewController {
         tabBar.invalidateLayout()
         tabOverview.refreshForCurrentOrientation()
     }
-    
+
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         performContentLifecycle {
@@ -209,9 +225,9 @@ final class BrowserViewController: UIViewController {
             }
         }
     }
-    
+
     // MARK: - Browser Layout
-    
+
     private func configureBrowserInterface() {
         browserChrome.configureAddressBar(
             delegate: self,
@@ -221,34 +237,34 @@ final class BrowserViewController: UIViewController {
         configureBrowserChromeActions()
         tabBar.dataSource = self
         tabOverview.configure(dataSource: self, delegate: self, presentationContext: self)
-        
+
         view.addSubview(contentView)
         view.addSubview(tabBar)
         view.addSubview(browserChrome)
         view.addSubview(tabOverview)
-        
+
         NSLayoutConstraint.activate([
             contentView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             contentView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).withPriority(.defaultHigh),
             contentView.bottomAnchor.constraint(equalTo: browserChrome.bottomToolbarTopAnchor).withPriority(.defaultHigh),
-            
+
             browserChrome.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             browserChrome.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             browserChrome.topAnchor.constraint(equalTo: view.topAnchor),
             browserChrome.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            
+
             tabBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tabBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tabBar.topAnchor.constraint(equalTo: browserChrome.topToolbarBottomAnchor),
-            
+
             tabOverview.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tabOverview.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tabOverview.topAnchor.constraint(equalTo: view.topAnchor),
             tabOverview.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
     }
-    
+
     private func configureBrowserChromeActions() {
         browserChrome.onSidebar = { [weak self] in
             self?.sidebarCoordinator.toggle(animated: true)
@@ -275,7 +291,7 @@ final class BrowserViewController: UIViewController {
             self?.setTabOverviewVisible(true, animated: true)
         }
     }
-    
+
     func updateBrowserLayout(
         animated: Bool,
         duration: TimeInterval = UX.layoutAnimationDuration
@@ -287,21 +303,27 @@ final class BrowserViewController: UIViewController {
             )
             return
         }
-        
+
         browserLayout = resolveBrowserLayout()
         applyBrowserLayout()
         searchOverlayCoordinator.updateLayoutIfNeeded()
-        
+        reapplyKeyboardAvoidance(
+            animation: KeyboardAnimation(
+                duration: animated ? duration : 0,
+                curve: [.beginFromCurrentState, .allowUserInteraction]
+            )
+        )
+
         let layoutBlock = {
             self.view.layoutIfNeeded()
             self.tabOverview.collection.applyPresentationTransforms()
         }
-        
+
         animated
         ? UIView.animate(withDuration: duration, animations: layoutBlock)
         : layoutBlock()
     }
-    
+
     func updateBrowserLayoutIfNeeded(
         animated: Bool,
         duration: TimeInterval = UX.layoutAnimationDuration
@@ -309,10 +331,10 @@ final class BrowserViewController: UIViewController {
         guard browserLayout != resolveBrowserLayout() else {
             return
         }
-        
+
         updateBrowserLayout(animated: animated, duration: duration)
     }
-    
+
     func applyBrowserLayout() {
         if isShowingFullscreenMedia {
             applyFullscreenLayout()
@@ -326,12 +348,12 @@ final class BrowserViewController: UIViewController {
                 applyPadLayout()
             }
         }
-        
+
         applyTabOverviewLayout()
         applyBrowserChromeLayout()
         updateNavigationButtons()
     }
-    
+
     private func applyFullscreenLayout() {
         contentView.applyLayout(
             ContentView.LayoutState(mode: .fullscreen),
@@ -340,7 +362,7 @@ final class BrowserViewController: UIViewController {
         )
         tabBar.setVisibility(.hidden, animated: false)
     }
-    
+
     private func applyPhoneLayout() {
         let isSearchFocused = searchOverlayCoordinator.isFocused && !tabOverview.isPresented
         contentView.applyLayout(
@@ -352,7 +374,7 @@ final class BrowserViewController: UIViewController {
         )
         setTabBarVisible(false)
     }
-    
+
     private func applyCompactLayout() {
         contentView.applyLayout(
             ContentView.LayoutState(mode: .standard),
@@ -361,7 +383,7 @@ final class BrowserViewController: UIViewController {
         )
         setTabBarVisible(false)
     }
-    
+
     private func applyPadLayout() {
         contentView.applyLayout(
             ContentView.LayoutState(mode: .standard),
@@ -373,28 +395,28 @@ final class BrowserViewController: UIViewController {
         : visibleTabCount > 1 && Prefs.AppearanceSettings.showsLandscapeTabBar
         setTabBarVisible(showsTabBar)
     }
-    
+
     private var visibleTabCount: Int {
         let tabs = tabManager.selectedTabMode == .private
         ? tabManager.privateTabs
         : tabManager.regularTabs
         return tabs.count
     }
-    
+
     private func setTabBarVisible(_ visible: Bool) {
         tabBar.setVisibility(
             visible ? (tabOverview.isPresented ? .layoutReserved : .visible) : .hidden,
             animated: false
         )
     }
-    
+
     private func applyTabOverviewLayout() {
         tabOverview.applyLayout(
             toolbarPosition: browserLayout.tabOverviewToolbarPosition,
             animated: false
         )
     }
-    
+
     private func applyBrowserChromeLayout() {
         browserChrome.apply(state: BrowserChrome.State(
             position: browserLayout.chromePosition,
@@ -408,77 +430,77 @@ final class BrowserViewController: UIViewController {
             sidebarButtonVisible: sidebarCoordinator.showChromeSidebarButton
         ))
     }
-    
+
     private func resolveBrowserLayout() -> BrowserLayout {
         let interfaceIdiom = traitCollection.userInterfaceIdiom
         let orientation = currentViewportOrientation()
-        
+
         if interfaceIdiom == .pad {
             return isCompactPadLayout
             ? resolveCompactLayout(interfaceIdiom: .pad, orientation: orientation)
             : resolvePadLayout(interfaceIdiom: .pad, orientation: orientation)
         }
-        
+
         guard orientation == .portrait else {
             return resolvePadLayout(interfaceIdiom: .phone, orientation: .landscape)
         }
-        
+
         return Prefs.AppearanceSettings.addressBarPosition == .top
         ? resolveCompactLayout(interfaceIdiom: .phone, orientation: .portrait)
         : resolvePhoneLayout()
     }
-    
+
     private func currentViewportOrientation() -> BrowserLayout.ViewportOrientation {
         if let interfaceOrientation = view.window?.windowScene?.interfaceOrientation,
            interfaceOrientation != .unknown {
             return interfaceOrientation.isLandscape ? .landscape : .portrait
         }
-        
+
         return view.bounds.width > view.bounds.height ? .landscape : .portrait
     }
-    
+
     var isCompactPadLayout: Bool {
         guard let window = view.window else {
             return UIApplication.shared.shouldUseCompactPadLayout
         }
-        
+
         return UIApplication.shared.shouldUseCompactPadLayout(
             forWindowWidth: browserWindowWidth(fallback: window.bounds.width),
             screen: window.screen
         )
     }
-    
+
     var isSidebarOverlayLayout: Bool {
         guard let window = view.window else {
             return UIApplication.shared.isSidebarOverlayWidth
         }
-        
+
         return UIApplication.shared.isSidebarOverlayWidth(
             forWindowWidth: browserWindowWidth(fallback: window.bounds.width),
             screen: window.screen
         )
     }
-    
+
     private var shouldUseBottomTabOverviewToolbar: Bool {
         guard let window = view.window else {
             return UIApplication.shared.shouldUseBottomTabOverviewToolbar
         }
-        
+
         return UIApplication.shared.shouldUseBottomTabOverviewToolbar(
             forWindowWidth: browserWindowWidth(fallback: window.bounds.width),
             screen: window.screen
         )
     }
-    
+
     private func browserWindowWidth(fallback: CGFloat) -> CGFloat {
         guard let rootView = view.window?.rootViewController?.view,
               rootView.bounds.width > 0 else {
             return fallback
         }
-        
+
         return rootView.bounds.width
     }
-    
+
     private func resolvePhoneLayout() -> BrowserLayout {
         return BrowserLayout(
             interfaceIdiom: .phone,
@@ -489,7 +511,7 @@ final class BrowserViewController: UIViewController {
             overlayHost: .embedded
         )
     }
-    
+
     private func resolveCompactLayout(
         interfaceIdiom: UIUserInterfaceIdiom,
         orientation: BrowserLayout.ViewportOrientation
@@ -503,7 +525,7 @@ final class BrowserViewController: UIViewController {
             overlayHost: .embedded
         )
     }
-    
+
     private func resolvePadLayout(
         interfaceIdiom: UIUserInterfaceIdiom,
         orientation: BrowserLayout.ViewportOrientation
@@ -517,23 +539,23 @@ final class BrowserViewController: UIViewController {
             overlayHost: .detached
         )
     }
-    
+
     private func browserTopInset() -> CGFloat {
         return sidebarCoordinator.topInset(fallback: UX.fallbackTopInset)
     }
-    
+
     // MARK: - Sidebar
-    
+
     private func performContentLifecycle(_ action: () -> Void) {
         guard !sidebarCoordinator.hostsSidebar else {
             return
         }
-        
+
         action()
     }
-    
+
     // MARK: - Notifications
-    
+
     private func observeNotifications() {
         NotificationCenter.default.addObserver(
             self,
@@ -608,25 +630,45 @@ final class BrowserViewController: UIViewController {
             object: nil
         )
     }
-    
+
     // MARK: - Keyboard
-    
+
     @objc private func keyboardFrameWillChange(_ notification: Notification) {
         guard let frameValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
             return
         }
-        
+
         let keyboardFrame = view.convert(frameValue.cgRectValue, from: nil)
-        let keyboardIntersection = view.bounds.intersection(keyboardFrame)
-        let keyboardInset = max(
-            0,
-            keyboardIntersection.height - view.safeAreaInsets.bottom
-        )
-        visibleKeyboardFrame = keyboardInset > 0 ? keyboardFrame : nil
         let animation = keyboardAnimation(from: notification)
-        if !searchOverlayCoordinator.isFocused && !tabOverview.isPresented && keyboardInset > 0 {
-            contentView.relocateFocusedInput(
-                above: keyboardFrame,
+        let state = keyboardAvoidanceState(for: keyboardFrame)
+        visibleKeyboardFrame = state.hasKeyboardOverlap ? keyboardFrame : nil
+        applyKeyboardAvoidance(state, animation: animation)
+    }
+
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        let animation = keyboardAnimation(from: notification)
+        visibleKeyboardFrame = nil
+        applyKeyboardAvoidance(.inactive, animation: animation)
+    }
+
+    private func reapplyKeyboardAvoidance(animation: KeyboardAnimation) {
+        guard let visibleKeyboardFrame else {
+            return
+        }
+
+        let state = keyboardAvoidanceState(for: visibleKeyboardFrame)
+        self.visibleKeyboardFrame = state.hasKeyboardOverlap ? visibleKeyboardFrame : nil
+        applyKeyboardAvoidance(state, animation: animation)
+    }
+
+    private func applyKeyboardAvoidance(
+        _ state: KeyboardAvoidanceState,
+        animation: KeyboardAnimation
+    ) {
+        if shouldApplyPageKeyboardAvoidance(state) {
+            contentView.applyPageKeyboardAvoidance(
+                bottomInset: state.pageViewportBottomInset,
+                above: state.keyboardFrame ?? .null,
                 animationDuration: animation.duration,
                 animationOptions: animation.curve
             )
@@ -636,26 +678,85 @@ final class BrowserViewController: UIViewController {
                 animationOptions: animation.curve
             )
         }
-        
+
         let shouldDockChrome = browserLayout.chromeMode == .phone
         && searchOverlayCoordinator.isFocused
         && !tabOverview.isPresented
-        && keyboardInset > 0
-        browserChrome.dockAddressBar(offset: shouldDockChrome ? -keyboardInset : 0)
-        animateLayout(animation)
-    }
-    
-    @objc private func keyboardWillHide(_ notification: Notification) {
-        let animation = keyboardAnimation(from: notification)
-        visibleKeyboardFrame = nil
-        contentView.resetFocusedInputRelocation(
-            animationDuration: animation.duration,
-            animationOptions: animation.curve
+        && state.hasKeyboardOverlap
+        browserChrome.dockAddressBar(
+            offset: shouldDockChrome ? -state.keyboardOverlapHeight : 0
         )
-        browserChrome.dockAddressBar(offset: 0)
         animateLayout(animation)
     }
-    
+
+    private func shouldApplyPageKeyboardAvoidance(_ state: KeyboardAvoidanceState) -> Bool {
+        state.hasKeyboardOverlap
+        && !searchOverlayCoordinator.isFocused
+        && !tabOverview.isPresented
+        && !isShowingFullscreenMedia
+        && state.pageViewportBottomInset > 0
+    }
+
+    private func keyboardAvoidanceState(for keyboardFrame: CGRect?) -> KeyboardAvoidanceState {
+        guard let keyboardFrame else {
+            return .inactive
+        }
+
+        view.layoutIfNeeded()
+        let keyboardOverlap = Self.keyboardOverlapHeight(
+            in: view.bounds,
+            safeAreaBottomInset: view.safeAreaInsets.bottom,
+            keyboardFrame: keyboardFrame
+        )
+        guard keyboardOverlap > 0 else {
+            return .inactive
+        }
+
+        let contentFrame = contentView.keyboardAvoidanceReferenceFrame(in: view)
+        return KeyboardAvoidanceState(
+            keyboardFrame: keyboardFrame,
+            keyboardOverlapHeight: keyboardOverlap,
+            pageViewportBottomInset: Self.pageViewportBottomInset(
+                contentFrame: contentFrame,
+                keyboardFrame: keyboardFrame
+            )
+        )
+    }
+
+    private static func keyboardOverlapHeight(
+        in bounds: CGRect,
+        safeAreaBottomInset: CGFloat,
+        keyboardFrame: CGRect
+    ) -> CGFloat {
+        let intersection = bounds.intersection(keyboardFrame)
+        guard !intersection.isNull,
+              intersection.height > 0,
+              intersection.width > 0 else {
+            return 0
+        }
+
+        return max(0, intersection.height - safeAreaBottomInset)
+    }
+
+    private static func pageViewportBottomInset(
+        contentFrame: CGRect,
+        keyboardFrame: CGRect
+    ) -> CGFloat {
+        guard contentFrame.height > 1,
+              contentFrame.width > 1 else {
+            return 0
+        }
+
+        let intersection = contentFrame.intersection(keyboardFrame)
+        guard !intersection.isNull,
+              intersection.height > 0,
+              intersection.width > 0 else {
+            return 0
+        }
+
+        return max(0, contentFrame.maxY - intersection.minY)
+    }
+
     private func keyboardAnimation(from notification: Notification) -> KeyboardAnimation {
         let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval
         ?? UX.keyboardAnimationDuration
@@ -666,9 +767,18 @@ final class BrowserViewController: UIViewController {
             curve: UIView.AnimationOptions(rawValue: rawCurve << 16)
         )
     }
-    
+
     private func animateLayout(_ animation: KeyboardAnimation) {
-        UIView.animate(withDuration: animation.duration, delay: 0, options: [animation.curve]) {
+        guard animation.duration > 0 else {
+            view.layoutIfNeeded()
+            return
+        }
+
+        UIView.animate(
+            withDuration: animation.duration,
+            delay: 0,
+            options: [animation.curve, .beginFromCurrentState, .allowUserInteraction]
+        ) {
             self.view.layoutIfNeeded()
         }
     }
@@ -698,6 +808,9 @@ final class BrowserViewController: UIViewController {
         updateNavigationButtons()
         applyPageZoomToSelectedTab()
         updateBrowserLayout(animated: false)
+        reapplyKeyboardAvoidance(
+            animation: KeyboardAnimation(duration: 0, curve: [])
+        )
     }
 
     @objc private func appearancePreferencesDidChange() {
@@ -732,26 +845,29 @@ final class BrowserViewController: UIViewController {
         view.tintColor = BrowserAppearance.accentColor
         setNeedsStatusBarAppearanceUpdate()
     }
-    
+
     @objc func addressBarPositionDidChange() {
         updateBrowserLayout(animated: true)
     }
-    
+
     @objc func landscapeTabBarDidChange() {
         updateBrowserLayout(animated: true)
     }
-    
+
     @objc func applyUpdateMenuButtonBadge() {
         browserChrome.setMenuButtonIndicatesUpdate(BrowserUpdates.shared.hasUpdate)
     }
-    
+
     @objc func pageZoomPreferencesDidChange() {
         applyPageZoomToSelectedTab()
         refreshAddressBar()
+        reapplyKeyboardAvoidance(
+            animation: KeyboardAnimation(duration: 0, curve: [])
+        )
     }
 
     // MARK: - Browser UI Updates
-    
+
     func syncBrowserNavigationChrome(animated: Bool) {
         navigationController?.setNavigationBarHidden(true, animated: animated)
         navigationItem.leftItemsSupplementBackButton = false
@@ -759,30 +875,30 @@ final class BrowserViewController: UIViewController {
         navigationItem.leftBarButtonItems = []
         navigationItem.leftBarButtonItem = nil
     }
-    
+
     func updateNavigationButtons() {
         guard let tab = tabManager.selectedTab else {
             return
         }
-        
+
         browserChrome.updateNavigation(
             canGoBack: tab.state.navigationState.canGoBack,
             canGoForward: tab.state.navigationState.canGoForward,
             canShare: tabManager.shareableURL(for: tab) != nil
         )
     }
-    
+
     func applyFullscreenState(_ fullScreen: Bool, for session: GeckoSession?) {
         if fullScreen {
             fullscreenSession = session
         } else if fullscreenSession === session || session == nil {
             fullscreenSession = nil
         }
-        
+
         guard isShowingFullscreenMedia != fullScreen else {
             return
         }
-        
+
         if fullScreen {
             if tabOverview.isPresented {
                 tabOverview.setPresented(false, animated: false)
@@ -790,23 +906,23 @@ final class BrowserViewController: UIViewController {
             searchOverlayCoordinator.setFocused(false, animated: false)
             view.endEditing(true)
         }
-        
+
         sidebarCoordinator.setFullscreen(fullScreen)
         isShowingFullscreenMedia = fullScreen
         updateBrowserLayout(animated: true)
         updateFullscreenOrientation(fullScreen)
         UIApplication.shared.isIdleTimerDisabled = fullScreen
     }
-    
+
     private func updateFullscreenOrientation(_ fullScreen: Bool) {
         guard browserLayout.interfaceIdiom == .phone else {
             return
         }
-        
+
         if #available(iOS 16.0, *) {
             setNeedsUpdateOfSupportedInterfaceOrientations()
         }
-        
+
         if fullScreen {
             if let currentOrientation = view.window?.windowScene?.interfaceOrientation,
                currentOrientation != .unknown {
@@ -814,7 +930,7 @@ final class BrowserViewController: UIViewController {
             } else if preFullscreenOrientation == nil {
                 preFullscreenOrientation = .portrait
             }
-            
+
             let targetOrientation: UIInterfaceOrientation
             if let currentOrientation = view.window?.windowScene?.interfaceOrientation,
                currentOrientation.isLandscape {
@@ -829,7 +945,7 @@ final class BrowserViewController: UIViewController {
             preFullscreenOrientation = nil
         }
     }
-    
+
     private func forceInterfaceOrientation(_ orientation: UIInterfaceOrientation) {
         let orientationMask: UIInterfaceOrientationMask
         switch orientation {
@@ -844,18 +960,18 @@ final class BrowserViewController: UIViewController {
         default:
             return
         }
-        
+
         if #available(iOS 16.0, *) {
             guard let windowScene = view.window?.windowScene else {
                 return
             }
-            
+
             let geometryPreferences = UIWindowScene.GeometryPreferences.iOS(interfaceOrientations: orientationMask)
             windowScene.requestGeometryUpdate(geometryPreferences)
             UIViewController.attemptRotationToDeviceOrientation()
             return
         }
-        
+
         let deviceOrientation: UIDeviceOrientation
         switch orientation {
         case .portrait:
@@ -869,7 +985,7 @@ final class BrowserViewController: UIViewController {
         default:
             return
         }
-        
+
         UIDevice.current.setValue(deviceOrientation.rawValue, forKey: "orientation")
         UIViewController.attemptRotationToDeviceOrientation()
     }

--- a/browser/Reynard/Client/Interface/BrowserViewController.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController.swift
@@ -800,9 +800,8 @@ final class BrowserViewController: UIViewController {
         }
 
         BrowserAppearance.apply(to: view.window)
-        if let session = tabManager.selectedTab?.session {
-            sessionManager.activate(session)
-        }
+        let replacedClosedSession = tabManager.recoverSelectedTabForForeground()
+        restoreSelectedContentAfterForeground(allowsSessionRebuild: !replacedClosedSession)
         syncBrowserNavigationChrome(animated: false)
         refreshAddressBar()
         updateNavigationButtons()
@@ -811,6 +810,32 @@ final class BrowserViewController: UIViewController {
         reapplyKeyboardAvoidance(
             animation: KeyboardAnimation(duration: 0, curve: [])
         )
+    }
+
+    private func restoreSelectedContentAfterForeground(allowsSessionRebuild: Bool) {
+        guard let selectedTab = tabManager.selectedTab else {
+            contentView.setSession(nil)
+            return
+        }
+
+        if !contentView.isDisplaying(session: selectedTab.session) {
+            contentView.setSession(selectedTab.session)
+        }
+        contentView.restoreInteraction(for: selectedTab.session)
+        updateBrowserLayout(animated: false)
+        view.layoutIfNeeded()
+
+        guard allowsSessionRebuild,
+              !contentView.hasRenderableContent(for: selectedTab.session),
+              tabManager.rebuildSelectedTabSessionForForeground(),
+              let recoveredTab = tabManager.selectedTab else {
+            return
+        }
+
+        contentView.setSession(recoveredTab.session)
+        contentView.restoreInteraction(for: recoveredTab.session)
+        updateBrowserLayout(animated: false)
+        view.layoutIfNeeded()
     }
 
     @objc private func appearancePreferencesDidChange() {

--- a/browser/Reynard/Client/Interface/BrowserViewController.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController.swift
@@ -559,6 +559,12 @@ final class BrowserViewController: UIViewController {
             name: .appUpdateAvailable,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(pageZoomPreferencesDidChange),
+            name: .pageZoomPreferencesDidChange,
+            object: nil
+        )
     }
     
     // MARK: - Keyboard
@@ -634,6 +640,11 @@ final class BrowserViewController: UIViewController {
         browserChrome.setMenuButtonIndicatesUpdate(BrowserUpdates.shared.hasUpdate)
     }
     
+    @objc func pageZoomPreferencesDidChange() {
+        applyPageZoomToSelectedTab()
+        refreshAddressBar()
+    }
+
     // MARK: - Browser UI Updates
     
     func syncBrowserNavigationChrome(animated: Bool) {

--- a/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBar.swift
+++ b/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBar.swift
@@ -13,9 +13,7 @@ protocol AddressBarDelegate: AnyObject {
     func addressBar(_ addressBar: AddressBar, didSelectAddon item: AddonMenuItem)
     func addressBarDidRequestWebsiteModeChange(_ addressBar: AddressBar)
     func addressBarDidRequestWebsiteSettings(_ addressBar: AddressBar)
-    func addressBarDidRequestPageZoomOut(_ addressBar: AddressBar)
-    func addressBarDidRequestPageZoomIn(_ addressBar: AddressBar)
-    func addressBarDidRequestPageZoomReset(_ addressBar: AddressBar)
+    func addressBarDidRequestPageZoomControls(_ addressBar: AddressBar)
     func addressBar(_ addressBar: AddressBar, didRequestBookmarkInFavorites favorites: Bool)
 }
 
@@ -227,7 +225,7 @@ final class AddressBar: UIView {
         configureHierarchy()
         configureConstraints()
         configureTargets()
-        applyState()
+        applyAppearance()
     }
     
     required init?(coder: NSCoder) {
@@ -307,17 +305,9 @@ final class AddressBar: UIView {
                 guard let self else { return }
                 self.delegate?.addressBarDidRequestWebsiteSettings(self)
             },
-            onPageZoomOut: { [weak self] in
+            onPageZoomControls: { [weak self] in
                 guard let self else { return }
-                self.delegate?.addressBarDidRequestPageZoomOut(self)
-            },
-            onPageZoomIn: { [weak self] in
-                guard let self else { return }
-                self.delegate?.addressBarDidRequestPageZoomIn(self)
-            },
-            onPageZoomReset: { [weak self] in
-                guard let self else { return }
-                self.delegate?.addressBarDidRequestPageZoomReset(self)
+                self.delegate?.addressBarDidRequestPageZoomControls(self)
             },
             onBookmark: { [weak self] favorites in
                 guard let self else { return }
@@ -437,6 +427,13 @@ final class AddressBar: UIView {
     
     func setLoadingProgress(_ progress: Float, isLoading: Bool) {
         loadingState = isLoading ? .loading(progress: progress) : .idle
+        applyState()
+    }
+
+    func applyAppearance() {
+        tintColor = BrowserAppearance.accentColor
+        addressBarContent.backgroundColor = BrowserAppearance.surfaceColor
+        progressView.progressTintColor = BrowserAppearance.accentColor
         applyState()
     }
     

--- a/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBar.swift
+++ b/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBar.swift
@@ -13,6 +13,9 @@ protocol AddressBarDelegate: AnyObject {
     func addressBar(_ addressBar: AddressBar, didSelectAddon item: AddonMenuItem)
     func addressBarDidRequestWebsiteModeChange(_ addressBar: AddressBar)
     func addressBarDidRequestWebsiteSettings(_ addressBar: AddressBar)
+    func addressBarDidRequestPageZoomOut(_ addressBar: AddressBar)
+    func addressBarDidRequestPageZoomIn(_ addressBar: AddressBar)
+    func addressBarDidRequestPageZoomReset(_ addressBar: AddressBar)
     func addressBar(_ addressBar: AddressBar, didRequestBookmarkInFavorites favorites: Bool)
 }
 
@@ -282,10 +285,15 @@ final class AddressBar: UIView {
         applyState()
     }
     
-    func updateMenu(url: String?, usesDesktopWebsite: Bool?) {
+    func updateMenu(
+        url: String?,
+        usesDesktopWebsite: Bool?,
+        pageZoom: AddressBarMenu.PageZoomState?
+    ) {
         addonsMenu = AddressBarMenu.makeMenu(
             selectedURL: url,
             usesDesktopWebsite: usesDesktopWebsite,
+            pageZoom: pageZoom,
             addonItems: delegate?.addressBarAddonItems(self) ?? [],
             onAddonSelected: { [weak self] item in
                 guard let self else { return }
@@ -298,6 +306,18 @@ final class AddressBar: UIView {
             onWebsiteSettings: { [weak self] in
                 guard let self else { return }
                 self.delegate?.addressBarDidRequestWebsiteSettings(self)
+            },
+            onPageZoomOut: { [weak self] in
+                guard let self else { return }
+                self.delegate?.addressBarDidRequestPageZoomOut(self)
+            },
+            onPageZoomIn: { [weak self] in
+                guard let self else { return }
+                self.delegate?.addressBarDidRequestPageZoomIn(self)
+            },
+            onPageZoomReset: { [weak self] in
+                guard let self else { return }
+                self.delegate?.addressBarDidRequestPageZoomReset(self)
             },
             onBookmark: { [weak self] favorites in
                 guard let self else { return }

--- a/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBarMenu.swift
+++ b/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBarMenu.swift
@@ -34,9 +34,7 @@ enum AddressBarMenu {
         onAddonSelected: @escaping (AddonMenuItem) -> Void,
         onChangeWebsiteMode: @escaping () -> Void,
         onWebsiteSettings: @escaping () -> Void,
-        onPageZoomOut: @escaping () -> Void,
-        onPageZoomIn: @escaping () -> Void,
-        onPageZoomReset: @escaping () -> Void,
+        onPageZoomControls: @escaping () -> Void,
         onBookmark: @escaping (Bool) -> Void
     ) -> UIMenu {
         var tabActions: [UIMenuElement] = []
@@ -93,9 +91,7 @@ enum AddressBarMenu {
         if let pageZoom {
             pageActions.append(pageZoomMenu(
                 state: pageZoom,
-                onZoomOut: onPageZoomOut,
-                onZoomIn: onPageZoomIn,
-                onReset: onPageZoomReset
+                onControls: onPageZoomControls
             ))
         }
 
@@ -113,45 +109,32 @@ enum AddressBarMenu {
 
     private static func pageZoomMenu(
         state: PageZoomState,
-        onZoomOut: @escaping () -> Void,
-        onZoomIn: @escaping () -> Void,
-        onReset: @escaping () -> Void
+        onControls: @escaping () -> Void
     ) -> UIMenu {
-        let zoomOutAttributes: UIMenuElement.Attributes = state.canZoomOut ? [] : .disabled
-        let zoomInAttributes: UIMenuElement.Attributes = state.canZoomIn ? [] : .disabled
-        let resetAttributes: UIMenuElement.Attributes = state.hasSiteOverride ? [] : .disabled
         let defaultTitle = PageZoomLevel.displayTitle(for: state.defaultPercent)
+        let currentTitle = PageZoomLevel.displayTitle(for: state.percent)
 
-        return UIMenu(
-            title: "Page Zoom",
+        let menu = UIMenu(
+            title: "Page Zoom \(currentTitle)",
             image: UIImage(systemName: "textformat.size"),
             children: [
                 UIAction(
-                    title: "Zoom Out",
-                    image: UIImage(systemName: "minus.magnifyingglass"),
-                    attributes: zoomOutAttributes
-                ) { _ in
-                    onZoomOut()
-                },
-                UIAction(
-                    title: PageZoomLevel.displayTitle(for: state.percent),
+                    title: state.hasSiteOverride ? "Site Override: \(currentTitle)" : "Default: \(defaultTitle)",
                     attributes: .disabled
                 ) { _ in },
                 UIAction(
-                    title: "Zoom In",
-                    image: UIImage(systemName: "plus.magnifyingglass"),
-                    attributes: zoomInAttributes
+                    title: "Open Page Zoom Controls",
+                    image: UIImage(systemName: "slider.horizontal.3")
                 ) { _ in
-                    onZoomIn()
-                },
-                UIAction(
-                    title: "Reset to Default (\(defaultTitle))",
-                    image: UIImage(named: "reynard.arrow.clockwise"),
-                    attributes: resetAttributes
-                ) { _ in
-                    onReset()
+                    onControls()
                 },
             ]
         )
+
+        if #available(iOS 15.0, *) {
+            menu.subtitle = state.hasSiteOverride ? "Default \(defaultTitle)" : nil
+        }
+
+        return menu
     }
 }

--- a/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBarMenu.swift
+++ b/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBarMenu.swift
@@ -18,13 +18,25 @@ enum AddressBarMenu {
         let image: UIImage?
     }
     
+    struct PageZoomState {
+        let percent: Int
+        let defaultPercent: Int
+        let hasSiteOverride: Bool
+        let canZoomOut: Bool
+        let canZoomIn: Bool
+    }
+
     static func makeMenu(
         selectedURL: String?,
         usesDesktopWebsite: Bool?,
+        pageZoom: PageZoomState?,
         addonItems: [AddonItem],
         onAddonSelected: @escaping (AddonMenuItem) -> Void,
         onChangeWebsiteMode: @escaping () -> Void,
         onWebsiteSettings: @escaping () -> Void,
+        onPageZoomOut: @escaping () -> Void,
+        onPageZoomIn: @escaping () -> Void,
+        onPageZoomReset: @escaping () -> Void,
         onBookmark: @escaping (Bool) -> Void
     ) -> UIMenu {
         var tabActions: [UIMenuElement] = []
@@ -78,6 +90,15 @@ enum AddressBarMenu {
             })
         }
         
+        if let pageZoom {
+            pageActions.append(pageZoomMenu(
+                state: pageZoom,
+                onZoomOut: onPageZoomOut,
+                onZoomIn: onPageZoomIn,
+                onReset: onPageZoomReset
+            ))
+        }
+
         var settingsActions: [UIMenuElement] = []
         if url?.host != nil {
             settingsActions.append(UIAction(title: "Website Settings", image: UIImage(named: "reynard.gear")) { _ in
@@ -88,5 +109,49 @@ enum AddressBarMenu {
         let children = tabActions + [UIMenu(options: .displayInline, children: pageActions)] + [UIMenu(options: .displayInline, children: settingsActions)]
         
         return UIMenu(title: "", image: nil, identifier: Identifier.addressBarMenu, options: [], children: children)
+    }
+
+    private static func pageZoomMenu(
+        state: PageZoomState,
+        onZoomOut: @escaping () -> Void,
+        onZoomIn: @escaping () -> Void,
+        onReset: @escaping () -> Void
+    ) -> UIMenu {
+        let zoomOutAttributes: UIMenuElement.Attributes = state.canZoomOut ? [] : .disabled
+        let zoomInAttributes: UIMenuElement.Attributes = state.canZoomIn ? [] : .disabled
+        let resetAttributes: UIMenuElement.Attributes = state.hasSiteOverride ? [] : .disabled
+        let defaultTitle = PageZoomLevel.displayTitle(for: state.defaultPercent)
+
+        return UIMenu(
+            title: "Page Zoom",
+            image: UIImage(systemName: "textformat.size"),
+            children: [
+                UIAction(
+                    title: "Zoom Out",
+                    image: UIImage(systemName: "minus.magnifyingglass"),
+                    attributes: zoomOutAttributes
+                ) { _ in
+                    onZoomOut()
+                },
+                UIAction(
+                    title: PageZoomLevel.displayTitle(for: state.percent),
+                    attributes: .disabled
+                ) { _ in },
+                UIAction(
+                    title: "Zoom In",
+                    image: UIImage(systemName: "plus.magnifyingglass"),
+                    attributes: zoomInAttributes
+                ) { _ in
+                    onZoomIn()
+                },
+                UIAction(
+                    title: "Reset to Default (\(defaultTitle))",
+                    image: UIImage(named: "reynard.arrow.clockwise"),
+                    attributes: resetAttributes
+                ) { _ in
+                    onReset()
+                },
+            ]
+        )
     }
 }

--- a/browser/Reynard/Client/Interface/Chrome/AddressBar/PageZoomControlsViewController.swift
+++ b/browser/Reynard/Client/Interface/Chrome/AddressBar/PageZoomControlsViewController.swift
@@ -1,0 +1,230 @@
+//
+//  PageZoomControlsViewController.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import UIKit
+
+final class PageZoomControlsViewController: UIViewController {
+    private enum UX {
+        static let horizontalInset: CGFloat = 20
+        static let verticalInset: CGFloat = 20
+        static let controlSpacing: CGFloat = 18
+        static let buttonSpacing: CGFloat = 12
+        static let percentFontSize: CGFloat = 36
+        static let hostFontSize: CGFloat = 14
+        static let buttonHeight: CGFloat = 44
+    }
+
+    var onChange: (() -> Void)?
+
+    private let urlString: String
+    private let pageTitle: String
+    private let store: PageZoomStore
+    private var currentPercent: Int
+
+    private let hostLabel = UILabel()
+    private let percentLabel = UILabel()
+    private let defaultLabel = UILabel()
+    private let slider = UISlider()
+    private let zoomOutButton = UIButton(type: .system)
+    private let zoomInButton = UIButton(type: .system)
+    private let resetButton = UIButton(type: .system)
+
+    init(urlString: String, pageTitle: String, store: PageZoomStore = .shared) {
+        self.urlString = urlString
+        self.pageTitle = pageTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.store = store
+        self.currentPercent = store.zoomPercent(for: urlString)
+        super.init(nibName: nil, bundle: nil)
+        title = "Page Zoom"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureView()
+        configureControls()
+        applyCurrentState(notify: false)
+    }
+
+    private func configureView() {
+        view.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        navigationItem.rightBarButtonItem = UIBarButtonItem(
+            barButtonSystemItem: .done,
+            target: self,
+            action: #selector(doneButtonTapped)
+        )
+    }
+
+    private func configureControls() {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = UX.controlSpacing
+        stack.alignment = .fill
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.directionalLayoutMargins = NSDirectionalEdgeInsets(
+            top: UX.verticalInset,
+            leading: UX.horizontalInset,
+            bottom: UX.verticalInset,
+            trailing: UX.horizontalInset
+        )
+
+        hostLabel.font = .systemFont(ofSize: UX.hostFontSize, weight: .medium)
+        hostLabel.textColor = .secondaryLabel
+        hostLabel.numberOfLines = 2
+        hostLabel.textAlignment = .center
+        hostLabel.text = hostTitle()
+
+        percentLabel.font = .systemFont(ofSize: UX.percentFontSize, weight: .bold)
+        percentLabel.textColor = .label
+        percentLabel.textAlignment = .center
+        percentLabel.adjustsFontSizeToFitWidth = true
+        percentLabel.minimumScaleFactor = 0.7
+
+        defaultLabel.font = .preferredFont(forTextStyle: .footnote)
+        defaultLabel.textColor = .secondaryLabel
+        defaultLabel.numberOfLines = 2
+        defaultLabel.textAlignment = .center
+
+        slider.minimumValue = 0
+        slider.maximumValue = Float(max(PageZoomLevel.allowedPercents.count - 1, 0))
+        slider.isContinuous = true
+        slider.addTarget(self, action: #selector(sliderDidChange), for: .valueChanged)
+
+        configureButton(
+            zoomOutButton,
+            title: "Zoom Out",
+            image: UIImage(systemName: "minus.magnifyingglass"),
+            action: #selector(zoomOutButtonTapped)
+        )
+        configureButton(
+            zoomInButton,
+            title: "Zoom In",
+            image: UIImage(systemName: "plus.magnifyingglass"),
+            action: #selector(zoomInButtonTapped)
+        )
+        configureButton(
+            resetButton,
+            title: "Reset",
+            image: UIImage(named: "reynard.arrow.clockwise") ?? UIImage(systemName: "arrow.counterclockwise"),
+            action: #selector(resetButtonTapped)
+        )
+
+        let buttonStack = UIStackView(arrangedSubviews: [zoomOutButton, resetButton, zoomInButton])
+        buttonStack.axis = .horizontal
+        buttonStack.spacing = UX.buttonSpacing
+        buttonStack.distribution = .fillEqually
+
+        [hostLabel, percentLabel, slider, buttonStack, defaultLabel].forEach(stack.addArrangedSubview)
+        view.addSubview(stack)
+
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            stack.bottomAnchor.constraint(lessThanOrEqualTo: view.safeAreaLayoutGuide.bottomAnchor),
+            zoomOutButton.heightAnchor.constraint(equalToConstant: UX.buttonHeight),
+            resetButton.heightAnchor.constraint(equalToConstant: UX.buttonHeight),
+            zoomInButton.heightAnchor.constraint(equalToConstant: UX.buttonHeight),
+        ])
+    }
+
+    private func configureButton(_ button: UIButton, title: String, image: UIImage?, action: Selector) {
+        button.setTitle(title, for: .normal)
+        button.setImage(image, for: .normal)
+        button.tintColor = BrowserAppearance.accentColor
+        button.titleLabel?.font = .preferredFont(forTextStyle: .body)
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+        button.titleLabel?.minimumScaleFactor = 0.75
+        button.layer.cornerCurve = .continuous
+        button.layer.cornerRadius = 8
+        button.backgroundColor = BrowserAppearance.secondarySurfaceColor
+        button.addTarget(self, action: action, for: .touchUpInside)
+        if #available(iOS 15.0, *) {
+            var configuration = UIButton.Configuration.plain()
+            configuration.title = title
+            configuration.image = image
+            configuration.imagePlacement = .top
+            configuration.imagePadding = 4
+            configuration.baseForegroundColor = BrowserAppearance.accentColor
+            configuration.titleLineBreakMode = .byTruncatingTail
+            configuration.background.backgroundColor = BrowserAppearance.secondarySurfaceColor
+            configuration.background.cornerRadius = 8
+            button.configuration = configuration
+        } else {
+            button.imageEdgeInsets = UIEdgeInsets(top: 0, left: -4, bottom: 0, right: 4)
+        }
+    }
+
+    private func hostTitle() -> String {
+        let host = DomainMatcher.host(from: urlString)
+        if !pageTitle.isEmpty, let host {
+            return "\(pageTitle)\n\(host)"
+        }
+
+        return host ?? pageTitle
+    }
+
+    private func applyCurrentState(notify: Bool) {
+        currentPercent = store.zoomPercent(for: urlString)
+        let defaultTitle = PageZoomLevel.displayTitle(for: store.defaultPercent)
+        let displayTitle = PageZoomLevel.displayTitle(for: currentPercent)
+        percentLabel.text = displayTitle
+        defaultLabel.text = store.hasOverride(for: urlString)
+        ? "Site override. Default is \(defaultTitle)."
+        : "Using the default page zoom of \(defaultTitle)."
+        slider.value = Float(PageZoomLevel.sliderIndex(for: currentPercent))
+        zoomOutButton.isEnabled = PageZoomLevel.lowerPercent(than: currentPercent) != nil
+        zoomInButton.isEnabled = PageZoomLevel.higherPercent(than: currentPercent) != nil
+        resetButton.isEnabled = store.hasOverride(for: urlString)
+
+        if notify {
+            onChange?()
+        }
+    }
+
+    private func setSitePercent(_ percent: Int) {
+        store.setOverridePercent(percent, for: urlString)
+        applyCurrentState(notify: true)
+    }
+
+    @objc private func sliderDidChange() {
+        let percent = PageZoomLevel.percent(forSliderValue: slider.value)
+        guard percent != currentPercent || !store.hasOverride(for: urlString) else {
+            slider.value = Float(PageZoomLevel.sliderIndex(for: currentPercent))
+            return
+        }
+
+        setSitePercent(percent)
+    }
+
+    @objc private func zoomOutButtonTapped() {
+        guard let percent = store.lowerPercent(for: urlString) else {
+            return
+        }
+        setSitePercent(percent)
+    }
+
+    @objc private func zoomInButtonTapped() {
+        guard let percent = store.higherPercent(for: urlString) else {
+            return
+        }
+        setSitePercent(percent)
+    }
+
+    @objc private func resetButtonTapped() {
+        store.resetOverride(for: urlString)
+        applyCurrentState(notify: true)
+    }
+
+    @objc private func doneButtonTapped() {
+        dismiss(animated: true)
+    }
+}

--- a/browser/Reynard/Client/Interface/Chrome/BrowserChrome.swift
+++ b/browser/Reynard/Client/Interface/Chrome/BrowserChrome.swift
@@ -359,6 +359,13 @@ final class BrowserChrome: UIView {
     func setSidebarButtonTransition(alpha: CGFloat, hidden: Bool) {
         topToolbar.setSidebarButtonTransition(alpha: alpha, hidden: hidden)
     }
+
+    func applyAppearance() {
+        topToolbar.applyAppearance()
+        bottomToolbar.applyAppearance()
+        addressBar.applyAppearance()
+        tintColor = BrowserAppearance.accentColor
+    }
     
     // MARK: - View Setup
     

--- a/browser/Reynard/Client/Interface/Chrome/BrowserChrome.swift
+++ b/browser/Reynard/Client/Interface/Chrome/BrowserChrome.swift
@@ -241,8 +241,16 @@ final class BrowserChrome: UIView {
         )
     }
     
-    func updateAddressBarMenu(url: String?, usesDesktopWebsite: Bool?) {
-        addressBar.updateMenu(url: url, usesDesktopWebsite: usesDesktopWebsite)
+    func updateAddressBarMenu(
+        url: String?,
+        usesDesktopWebsite: Bool?,
+        pageZoom: AddressBarMenu.PageZoomState?
+    ) {
+        addressBar.updateMenu(
+            url: url,
+            usesDesktopWebsite: usesDesktopWebsite,
+            pageZoom: pageZoom
+        )
     }
     
     func setAddressBarLoadingProgress(_ progress: Float, isLoading: Bool) {

--- a/browser/Reynard/Client/Interface/Chrome/Toolbar/BottomToolbar.swift
+++ b/browser/Reynard/Client/Interface/Chrome/Toolbar/BottomToolbar.swift
@@ -130,7 +130,7 @@ final class BottomToolbar: UIView {
             topConstraint.constant = verticalOffset - contentHeight
             contentHeightConstraint.constant = contentHeight
             isHidden = state == .hidden
-            backgroundColor = state == .focused ? .clear : .systemGray6
+            backgroundColor = state == .focused ? .clear : BrowserAppearance.toolbarBackgroundColor
             
             let isCompact = state == .compact
             standardButtonsTopConstraint?.isActive = !isCompact
@@ -166,6 +166,18 @@ final class BottomToolbar: UIView {
             for: .normal
         )
     }
+
+    func applyAppearance() {
+        backgroundColor = BrowserAppearance.toolbarBackgroundColor
+        [
+            backButton,
+            forwardButton,
+            shareButton,
+            libraryButton,
+            downloadButton,
+            tabOverviewButton,
+        ].forEach { $0.applyAppearance() }
+    }
     
     // MARK: - Action Wiring
     
@@ -180,7 +192,7 @@ final class BottomToolbar: UIView {
     
     private func configureAppearance() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = .systemGray6
+        applyAppearance()
     }
     
     private func configureHierarchy() {

--- a/browser/Reynard/Client/Interface/Chrome/Toolbar/ToolBarButton.swift
+++ b/browser/Reynard/Client/Interface/Chrome/Toolbar/ToolBarButton.swift
@@ -114,6 +114,12 @@ final class ToolbarButton: UIButton {
         downloadProgressFillWidthConstraint.constant = UX.downloadProgressTrackWidth * progress
         accessibilityLabel = "Downloads"
     }
+
+    func applyAppearance() {
+        tintColor = BrowserAppearance.accentColor
+        downloadIconView.tintColor = BrowserAppearance.accentColor
+        downloadProgressFillView.backgroundColor = BrowserAppearance.accentColor
+    }
     
     // MARK: - View Setup
     

--- a/browser/Reynard/Client/Interface/Chrome/Toolbar/TopToolbar.swift
+++ b/browser/Reynard/Client/Interface/Chrome/Toolbar/TopToolbar.swift
@@ -217,6 +217,20 @@ final class TopToolbar: UIView {
         sidebarButton.alpha = alpha
         sidebarButton.isHidden = hidden
     }
+
+    func applyAppearance() {
+        backgroundColor = BrowserAppearance.toolbarBackgroundColor
+        [
+            sidebarButton,
+            backButton,
+            forwardButton,
+            libraryButton,
+            downloadButton,
+            shareButton,
+            newTabButton,
+            tabOverviewButton,
+        ].forEach { $0.applyAppearance() }
+    }
     
     // MARK: - Action Wiring
     
@@ -233,7 +247,7 @@ final class TopToolbar: UIView {
     
     private func configureAppearance() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = .systemGray6
+        applyAppearance()
     }
     
     private func configureHierarchy() {

--- a/browser/Reynard/Client/Interface/ContentView/ContentView.swift
+++ b/browser/Reynard/Client/Interface/ContentView/ContentView.swift
@@ -70,7 +70,11 @@ final class ContentView: UIView {
     
     private func configureAppearance() {
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = .systemBackground
+        applyAppearance()
+    }
+
+    func applyAppearance() {
+        backgroundColor = BrowserAppearance.backgroundColor
     }
     
     private func configureHierarchy() {
@@ -177,7 +181,7 @@ final class ContentView: UIView {
             let bottomRatio = await session.focusedInputBottomRatio()
             guard !Task.isCancelled else { return }
             
-            inputBottomRatio = bottomRatio
+            inputBottomRatio = min(max(bottomRatio, 0), 1)
             superview?.layoutIfNeeded()
             let newOffset = calculateFocusedInputOffset(keyboardFrame: keyboardFrame)
             guard abs(newOffset - focusedInputOffset) > UX.focusedInputOffsetThreshold else {
@@ -195,8 +199,15 @@ final class ContentView: UIView {
         
         let unshiftedFrame = frame.offsetBy(dx: 0, dy: focusedInputOffset)
         guard unshiftedFrame.height > 1 else { return 0 }
+
+        let overlappingKeyboardFrame = unshiftedFrame.intersection(keyboardFrame)
+        guard !overlappingKeyboardFrame.isNull,
+              overlappingKeyboardFrame.height > 0,
+              overlappingKeyboardFrame.width > 0 else {
+            return 0
+        }
         
-        let keyboardOverlap = max(0, unshiftedFrame.maxY - keyboardFrame.minY)
+        let keyboardOverlap = max(0, unshiftedFrame.maxY - overlappingKeyboardFrame.minY)
         guard keyboardOverlap > 0 else { return 0 }
         
         let focusBottom = unshiftedFrame.height * inputBottomRatio

--- a/browser/Reynard/Client/Interface/ContentView/ContentView.swift
+++ b/browser/Reynard/Client/Interface/ContentView/ContentView.swift
@@ -180,6 +180,15 @@ final class ContentView: UIView {
             guard let self else { return }
             let bottomRatio = await session.focusedInputBottomRatio()
             guard !Task.isCancelled else { return }
+            guard let bottomRatio else {
+                inputBottomRatio = nil
+                guard focusedInputOffset != 0 else { return }
+
+                focusedInputOffset = 0
+                updateLayoutOffsets()
+                animateLayout(duration: animationDuration, options: animationOptions)
+                return
+            }
             
             inputBottomRatio = min(max(bottomRatio, 0), 1)
             superview?.layoutIfNeeded()

--- a/browser/Reynard/Client/Interface/ContentView/ContentView.swift
+++ b/browser/Reynard/Client/Interface/ContentView/ContentView.swift
@@ -13,43 +13,45 @@ final class ContentView: UIView {
         static let phoneSearchFocusedBottomInset: CGFloat = 94
         static let focusedInputBottomClearance: CGFloat = 12
         static let focusedInputOffsetThreshold: CGFloat = 0.5
+        static let maximumFocusedInputOffsetRatio: CGFloat = 0.45
     }
-    
+
     struct State: Equatable {
         let webVisibility: WebContentView.VisibilityState
         let overlayPresentation: OverlayContentView.PresentationState
-        
+
         static let browsing = State(
             webVisibility: .visible,
             overlayPresentation: .hidden
         )
     }
-    
+
     struct LayoutState: Equatable {
         enum Mode: Equatable {
             case standard
             case searchFocused
             case fullscreen
         }
-        
+
         let mode: Mode
     }
-    
+
     private(set) var state: State = .browsing
     private var layoutState = LayoutState(mode: .standard)
     private var session: GeckoSession?
     private var focusedInputTask: Task<Void, Never>?
     private var inputBottomRatio: CGFloat?
+    private var pageViewportBottomInset: CGFloat = 0
     private var focusedInputOffset: CGFloat = 0
-    
+
     private let webContentView = WebContentView()
     private let overlayContentView = OverlayContentView()
-    
+
     private var topConstraint: NSLayoutConstraint?
     private var bottomConstraint: NSLayoutConstraint?
-    
+
     // MARK: - Lifecycle
-    
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureAppearance()
@@ -57,17 +59,17 @@ final class ContentView: UIView {
         configureConstraints()
         applyState()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     deinit {
         focusedInputTask?.cancel()
     }
-    
+
     // MARK: - Configuration
-    
+
     private func configureAppearance() {
         translatesAutoresizingMaskIntoConstraints = false
         applyAppearance()
@@ -76,14 +78,14 @@ final class ContentView: UIView {
     func applyAppearance() {
         backgroundColor = BrowserAppearance.backgroundColor
     }
-    
+
     private func configureHierarchy() {
         webContentView.translatesAutoresizingMaskIntoConstraints = false
         overlayContentView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(webContentView)
         addSubview(overlayContentView)
     }
-    
+
     private func configureConstraints() {
         [webContentView, overlayContentView].forEach { contentView in
             NSLayoutConstraint.activate([
@@ -94,9 +96,9 @@ final class ContentView: UIView {
             ])
         }
     }
-    
+
     // MARK: - Layout
-    
+
     func applyLayout(
         _ layoutState: LayoutState,
         topAnchor: NSLayoutYAxisAnchor,
@@ -105,7 +107,7 @@ final class ContentView: UIView {
         self.layoutState = layoutState
         applyLayoutState(topAnchor: topAnchor, bottomAnchor: bottomAnchor)
     }
-    
+
     private func applyLayoutState(
         topAnchor: NSLayoutYAxisAnchor,
         bottomAnchor: NSLayoutYAxisAnchor
@@ -115,118 +117,139 @@ final class ContentView: UIView {
         guard canActivateConstraints([nextTopConstraint, nextBottomConstraint]) else {
             return
         }
-        
+
         topConstraint?.isActive = false
         bottomConstraint?.isActive = false
-        
+
         NSLayoutConstraint.activate([nextTopConstraint, nextBottomConstraint])
         topConstraint = nextTopConstraint
         bottomConstraint = nextBottomConstraint
         updateLayoutOffsets()
     }
-    
+
+    func keyboardAvoidanceReferenceFrame(in view: UIView) -> CGRect {
+        var referenceFrame = convert(bounds, to: view)
+        referenceFrame.origin.y += focusedInputOffset
+        referenceFrame.size.height += pageViewportBottomInset
+        return referenceFrame
+    }
+
     private func canActivateConstraints(_ constraints: [NSLayoutConstraint]) -> Bool {
         constraints.allSatisfy { constraint in
             guard let firstView = owningView(for: constraint.firstItem),
                   let secondView = owningView(for: constraint.secondItem) else {
                 return true
             }
-            
+
             return firstView.hasCommonAncestor(with: secondView)
         }
     }
-    
+
     private func owningView(for item: Any?) -> UIView? {
         if let view = item as? UIView {
             return view
         }
-        
+
         if let layoutGuide = item as? UILayoutGuide {
             return layoutGuide.owningView
         }
-        
+
         return nil
     }
-    
+
     private func updateLayoutOffsets() {
-        topConstraint?.constant = layoutState.mode == .fullscreen ? 0 : -focusedInputOffset
+        let contentOffset = layoutState.mode == .fullscreen ? 0 : focusedInputOffset
+        topConstraint?.constant = -contentOffset
         switch layoutState.mode {
         case .standard:
-            bottomConstraint?.constant = -focusedInputOffset
+            bottomConstraint?.constant = -(pageViewportBottomInset + contentOffset)
         case .searchFocused:
             bottomConstraint?.constant = -UX.phoneSearchFocusedBottomInset
         case .fullscreen:
             bottomConstraint?.constant = 0
         }
     }
-    
+
     // MARK: - Focused Input Relocation
-    
-    func relocateFocusedInput(
+
+    func applyPageKeyboardAvoidance(
+        bottomInset: CGFloat,
         above keyboardFrame: CGRect,
         animationDuration: TimeInterval,
         animationOptions: UIView.AnimationOptions
     ) {
         focusedInputTask?.cancel()
+        setKeyboardAvoidance(
+            bottomInset: bottomInset,
+            focusedOffset: focusedInputOffset,
+            animationDuration: animationDuration,
+            animationOptions: animationOptions
+        )
+
         guard let session else {
-            resetFocusedInputRelocation(
+            setKeyboardAvoidance(
+                bottomInset: bottomInset,
+                focusedOffset: 0,
                 animationDuration: animationDuration,
                 animationOptions: animationOptions
             )
             return
         }
-        
+
         focusedInputTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let bottomRatio = await session.focusedInputBottomRatio()
             guard !Task.isCancelled else { return }
             guard let bottomRatio else {
                 inputBottomRatio = nil
-                guard focusedInputOffset != 0 else { return }
-
-                focusedInputOffset = 0
-                updateLayoutOffsets()
-                animateLayout(duration: animationDuration, options: animationOptions)
+                setKeyboardAvoidance(
+                    bottomInset: bottomInset,
+                    focusedOffset: 0,
+                    animationDuration: animationDuration,
+                    animationOptions: animationOptions
+                )
                 return
             }
-            
-            inputBottomRatio = min(max(bottomRatio, 0), 1)
+
+            // Gecko reports this as a viewport-relative ratio; values above
+            // 1.0 mean the editable is below the current visible viewport.
+            inputBottomRatio = min(max(bottomRatio, 0), 2)
             superview?.layoutIfNeeded()
             let newOffset = calculateFocusedInputOffset(keyboardFrame: keyboardFrame)
             guard abs(newOffset - focusedInputOffset) > UX.focusedInputOffsetThreshold else {
                 return
             }
-            
-            focusedInputOffset = newOffset
-            updateLayoutOffsets()
-            animateLayout(duration: animationDuration, options: animationOptions)
+
+            setKeyboardAvoidance(
+                bottomInset: bottomInset,
+                focusedOffset: newOffset,
+                animationDuration: animationDuration,
+                animationOptions: animationOptions
+            )
         }
     }
-    
+
     private func calculateFocusedInputOffset(keyboardFrame: CGRect) -> CGFloat {
         guard let inputBottomRatio else { return 0 }
-        
-        let unshiftedFrame = frame.offsetBy(dx: 0, dy: focusedInputOffset)
-        guard unshiftedFrame.height > 1 else { return 0 }
 
-        let overlappingKeyboardFrame = unshiftedFrame.intersection(keyboardFrame)
-        guard !overlappingKeyboardFrame.isNull,
-              overlappingKeyboardFrame.height > 0,
-              overlappingKeyboardFrame.width > 0 else {
+        let currentHeight = bounds.height > 1 ? bounds.height : frame.height
+        guard currentHeight > 1 else { return 0 }
+
+        let contentFrame = convert(bounds, to: superview)
+        let keyboardOverlap = contentFrame.intersection(keyboardFrame)
+        guard keyboardOverlap.isNull || keyboardOverlap.height <= UX.focusedInputBottomClearance else {
             return 0
         }
-        
-        let keyboardOverlap = max(0, unshiftedFrame.maxY - overlappingKeyboardFrame.minY)
-        guard keyboardOverlap > 0 else { return 0 }
-        
-        let focusBottom = unshiftedFrame.height * inputBottomRatio
+
+        let focusBottom = currentHeight * inputBottomRatio
         let visibleBottom = max(
             0,
-            unshiftedFrame.height - keyboardOverlap - UX.focusedInputBottomClearance
+            currentHeight - UX.focusedInputBottomClearance
         )
-        return min(keyboardOverlap, max(0, focusBottom - visibleBottom))
+        let maximumOffset = currentHeight * UX.maximumFocusedInputOffsetRatio
+        return min(maximumOffset, max(0, focusBottom - visibleBottom))
     }
-    
+
     func resetFocusedInputRelocation(
         animationDuration: TimeInterval = 0,
         animationOptions: UIView.AnimationOptions = []
@@ -234,19 +257,39 @@ final class ContentView: UIView {
         focusedInputTask?.cancel()
         focusedInputTask = nil
         inputBottomRatio = nil
-        guard focusedInputOffset != 0 else { return }
-        
-        focusedInputOffset = 0
+        setKeyboardAvoidance(
+            bottomInset: 0,
+            focusedOffset: 0,
+            animationDuration: animationDuration,
+            animationOptions: animationOptions
+        )
+    }
+
+    private func setKeyboardAvoidance(
+        bottomInset: CGFloat,
+        focusedOffset: CGFloat,
+        animationDuration: TimeInterval,
+        animationOptions: UIView.AnimationOptions
+    ) {
+        let nextBottomInset = max(0, bottomInset)
+        let nextFocusedOffset = max(0, focusedOffset)
+        guard abs(nextBottomInset - pageViewportBottomInset) > UX.focusedInputOffsetThreshold
+                || abs(nextFocusedOffset - focusedInputOffset) > UX.focusedInputOffsetThreshold else {
+            return
+        }
+
+        pageViewportBottomInset = nextBottomInset
+        focusedInputOffset = nextFocusedOffset
         updateLayoutOffsets()
         animateLayout(duration: animationDuration, options: animationOptions)
     }
-    
+
     private func animateLayout(duration: TimeInterval, options: UIView.AnimationOptions) {
         guard duration > 0 else {
             superview?.layoutIfNeeded()
             return
         }
-        
+
         UIView.animate(
             withDuration: duration,
             delay: 0,
@@ -255,25 +298,25 @@ final class ContentView: UIView {
             self.superview?.layoutIfNeeded()
         }
     }
-    
+
     // MARK: - State
-    
+
     func setState(_ state: State) {
         guard self.state != state else {
             return
         }
-        
+
         self.state = state
         applyState()
     }
-    
+
     func setWebVisibility(_ visibility: WebContentView.VisibilityState) {
         setState(State(
             webVisibility: visibility,
             overlayPresentation: state.overlayPresentation
         ))
     }
-    
+
     func setOverlayPresentation(
         _ presentation: OverlayContentView.PresentationState,
         animated: Bool,
@@ -286,62 +329,62 @@ final class ContentView: UIView {
         webContentView.setVisibility(state.webVisibility)
         overlayContentView.setPresentation(presentation, animated: animated, completion: completion)
     }
-    
+
     private func applyState() {
         webContentView.setVisibility(state.webVisibility)
         overlayContentView.setPresentation(state.overlayPresentation, animated: false)
     }
-    
+
     // MARK: - Session
-    
+
     func setSession(_ session: GeckoSession?) {
         self.session = session
         resetFocusedInputRelocation()
         webContentView.setSession(session)
     }
-    
+
     func isDisplaying(session: GeckoSession) -> Bool {
         webContentView.isDisplaying(session: session)
     }
-    
+
     func restoreInteraction(for session: GeckoSession) {
         webContentView.restoreInteraction(for: session)
     }
-    
+
     // MARK: - Interaction
-    
+
     func addWebViewInteraction(_ interaction: UIInteraction) {
         webContentView.addWebViewInteraction(interaction)
     }
-    
+
     // MARK: - Presentation
-    
+
     func setTransitionTransform(_ transform: CGAffineTransform) {
         self.transform = transform
     }
-    
+
     func setTransitionHidden(_ hidden: Bool) {
         isHidden = hidden
     }
-    
+
     func frame(in view: UIView) -> CGRect {
         convert(bounds, to: view)
     }
-    
+
     func makeThumbnail() -> UIImage? {
         layoutIfNeeded()
         guard bounds.width > 1, bounds.height > 1 else {
             return nil
         }
-        
+
         let renderer = UIGraphicsImageRenderer(size: bounds.size)
         return renderer.image { context in
             layer.render(in: context.cgContext)
         }
     }
-    
+
     // MARK: - Overlay Hosting
-    
+
     func setOverlayController(
         _ viewController: UIViewController,
         for page: OverlayContentView.Page,
@@ -349,7 +392,7 @@ final class ContentView: UIView {
     ) {
         overlayContentView.setController(viewController, for: page, in: parentViewController)
     }
-    
+
     func removeOverlayController(for page: OverlayContentView.Page) {
         overlayContentView.removeController(for: page)
     }

--- a/browser/Reynard/Client/Interface/ContentView/ContentView.swift
+++ b/browser/Reynard/Client/Interface/ContentView/ContentView.swift
@@ -348,7 +348,22 @@ final class ContentView: UIView {
     }
 
     func restoreInteraction(for session: GeckoSession) {
+        self.session = session
+        isHidden = false
+        alpha = 1
+        isUserInteractionEnabled = true
         webContentView.restoreInteraction(for: session)
+    }
+
+    func hasRenderableContent(for session: GeckoSession) -> Bool {
+        layoutIfNeeded()
+        return !isHidden
+            && alpha > 0.01
+            && isUserInteractionEnabled
+            && window != nil
+            && bounds.width > 1
+            && bounds.height > 1
+            && webContentView.hasRenderableContent(for: session)
     }
 
     // MARK: - Interaction
@@ -397,4 +412,3 @@ final class ContentView: UIView {
         overlayContentView.removeController(for: page)
     }
 }
-

--- a/browser/Reynard/Client/Interface/ContentView/WebContentView.swift
+++ b/browser/Reynard/Client/Interface/ContentView/WebContentView.swift
@@ -65,7 +65,34 @@ final class WebContentView: UIView {
     }
     
     func restoreInteraction(for session: GeckoSession) {
-        webView.session = session
+        isHidden = false
+        alpha = 1
+        isUserInteractionEnabled = true
+        webView.isHidden = false
+        webView.alpha = 1
+        webView.isUserInteractionEnabled = true
+        if webView.session !== session {
+            webView.session = session
+        }
+        setNeedsLayout()
+        layoutIfNeeded()
+    }
+
+    func hasRenderableContent(for session: GeckoSession) -> Bool {
+        layoutIfNeeded()
+        return webView.session === session
+            && window != nil
+            && webView.window != nil
+            && !isHidden
+            && !webView.isHidden
+            && alpha > 0.01
+            && webView.alpha > 0.01
+            && isUserInteractionEnabled
+            && webView.isUserInteractionEnabled
+            && bounds.width > 1
+            && bounds.height > 1
+            && webView.bounds.width > 1
+            && webView.bounds.height > 1
     }
     
     func addWebViewInteraction(_ interaction: UIInteraction) {

--- a/browser/Reynard/Client/Interface/Library/Bookmarks/BookmarksViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Bookmarks/BookmarksViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class BookmarksViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate, UIGestureRecognizerDelegate {
+final class BookmarksViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate, UIGestureRecognizerDelegate, UIDocumentPickerDelegate {
     private enum UX {
         static let searchResultLimit = 50
         static let sectionHeaderTopPadding: CGFloat = 0
@@ -21,8 +21,12 @@ final class BookmarksViewController: UIViewController, UITableViewDataSource, UI
     private var sections: [(title: String, items: [BookmarkContentSnapshot])] = []
     private var query = ""
     private var searchVersion = 0
+    private var documentImportMode: DocumentImportMode?
     private var isRoot: Bool {
         return folderID == nil
+    }
+    private enum DocumentImportMode {
+        case bookmarks
     }
     private lazy var newFolderButton = UIBarButtonItem(
         title: "New Folder",
@@ -106,7 +110,7 @@ final class BookmarksViewController: UIViewController, UITableViewDataSource, UI
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .systemGroupedBackground
+        applyAppearance()
         installLayout()
         
         tableView.register(BookmarkItemCell.self, forCellReuseIdentifier: BookmarkItemCell.reuseIdentifier)
@@ -137,6 +141,7 @@ final class BookmarksViewController: UIViewController, UITableViewDataSource, UI
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        applyAppearance()
         navigationController?.setToolbarHidden(isRoot, animated: animated)
         installBookmarkNavigationMenuIfNeeded()
         reloadBookmarkRows()
@@ -468,7 +473,22 @@ final class BookmarksViewController: UIViewController, UITableViewDataSource, UI
                     self?.showNewFolderEditor()
                 },
             ]),
+            UIMenu(title: "", image: nil, identifier: nil, options: .displayInline, children: [
+                UIAction(title: "Import Bookmarks", image: UIImage(systemName: "square.and.arrow.down")) { [weak self] _ in
+                    self?.confirmBookmarkImport()
+                },
+                UIAction(title: "Export Bookmarks", image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+                    self?.confirmBookmarkExport()
+                },
+            ]),
         ])
+    }
+
+    private func applyAppearance() {
+        view.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        tableView.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        tableView.tintColor = BrowserAppearance.accentColor
+        navigationController?.navigationBar.tintColor = BrowserAppearance.accentColor
     }
     
     private func makeSortMenu() -> UIMenu {
@@ -739,6 +759,157 @@ final class BookmarksViewController: UIViewController, UITableViewDataSource, UI
             items = [flexibleSpace, editButtonItem]
         }
         setToolbarItems(items, animated: animated)
+    }
+
+    // MARK: - Bookmark Transfer
+
+    private func confirmBookmarkExport() {
+        let alert = UIAlertController(
+            title: "Export Bookmarks",
+            message: "This creates a local HTML bookmark file that may include private URLs and titles.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Export", style: .default) { [weak self] _ in
+            self?.exportBookmarks()
+        })
+        present(alert, animated: true)
+    }
+
+    private func exportBookmarks() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let bookmarks = self.store.allBookmarks()
+            let data = BookmarkHTMLTransfer.exportHTML(bookmarks: bookmarks)
+            let exportURL = FileManager.default.temporaryDirectory.appendingPathComponent(BookmarkHTMLTransfer.fileName)
+
+            do {
+                try data.write(to: exportURL, options: .atomic)
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentExportShareSheet(for: exportURL)
+                }
+            } catch {
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentTransferError(message: "Could not create the bookmark export file.")
+                }
+            }
+        }
+    }
+
+    private func presentExportShareSheet(for url: URL) {
+        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        controller.popoverPresentationController?.sourceView = view
+        controller.popoverPresentationController?.sourceRect = CGRect(
+            x: view.bounds.midX,
+            y: view.bounds.midY,
+            width: 1,
+            height: 1
+        )
+        present(controller, animated: true)
+    }
+
+    private func confirmBookmarkImport() {
+        let alert = UIAlertController(
+            title: "Import Bookmarks",
+            message: "Choose a Firefox/Netscape-style HTML bookmark file. Existing URLs are skipped.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Choose File", style: .default) { [weak self] _ in
+            self?.presentBookmarkImporter()
+        })
+        present(alert, animated: true)
+    }
+
+    private func presentBookmarkImporter() {
+        documentImportMode = .bookmarks
+        let controller = UIDocumentPickerViewController(
+            documentTypes: ["public.html", "public.text", "com.netscape.bookmark"],
+            in: .import
+        )
+        controller.delegate = self
+        controller.allowsMultipleSelection = false
+        present(controller, animated: true)
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard documentImportMode == .bookmarks,
+              let url = urls.first else {
+            documentImportMode = nil
+            return
+        }
+
+        documentImportMode = nil
+        importBookmarks(from: url)
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        documentImportMode = nil
+    }
+
+    private func importBookmarks(from url: URL) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self else {
+                return
+            }
+
+            let didStartAccessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if didStartAccessing {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            guard let data = try? Data(contentsOf: url) else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentTransferError(message: "Could not read the selected bookmark file.")
+                }
+                return
+            }
+
+            let importedItems = BookmarkHTMLTransfer.parseBookmarks(from: data)
+            var imported = 0
+            var skipped = 0
+            var seen = Set<URL>()
+
+            for item in importedItems {
+                guard seen.insert(item.url).inserted,
+                      self.store.bookmark(savedFor: item.url) == nil else {
+                    skipped += 1
+                    continue
+                }
+
+                if self.store.addBookmark(title: item.title, url: item.url) != nil {
+                    imported += 1
+                } else {
+                    skipped += 1
+                }
+            }
+
+            DispatchQueue.main.async { [weak self] in
+                self?.reloadBookmarkRows()
+                self?.presentImportSummary(DataImportSummary(imported: imported, skipped: skipped))
+            }
+        }
+    }
+
+    private func presentImportSummary(_ summary: DataImportSummary) {
+        let alert = UIAlertController(
+            title: "Import Complete",
+            message: "Imported \(summary.imported) bookmarks. Skipped \(summary.skipped).",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    private func presentTransferError(message: String) {
+        let alert = UIAlertController(title: "Transfer Failed", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
     
     // MARK: - Navigation

--- a/browser/Reynard/Client/Interface/Library/History/HistoryViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/History/HistoryViewController.swift
@@ -6,7 +6,7 @@
 
 import UIKit
 
-final class HistoryViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate, UIGestureRecognizerDelegate {
+final class HistoryViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UISearchBarDelegate, UIGestureRecognizerDelegate, UIDocumentPickerDelegate {
     private enum UX {
         static let estimatedRowHeight: CGFloat = 72
         static let sectionHeaderTopPadding: CGFloat = 0
@@ -67,7 +67,7 @@ final class HistoryViewController: UIViewController, UITableViewDataSource, UITa
     private lazy var tableView: UITableView = {
         let view = UITableView(frame: .zero, style: .insetGrouped)
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .systemGroupedBackground
+        view.backgroundColor = BrowserAppearance.groupedBackgroundColor
         view.dataSource = self
         view.delegate = self
         view.rowHeight = UITableView.automaticDimension
@@ -89,6 +89,11 @@ final class HistoryViewController: UIViewController, UITableViewDataSource, UITa
     private var query = ""
     private var loadVersion = 0
     private var skipsNextStoreReload = false
+    private var documentImportMode: DocumentImportMode?
+
+    private enum DocumentImportMode {
+        case history
+    }
     
     // MARK: - Lifecycle
     
@@ -99,7 +104,7 @@ final class HistoryViewController: UIViewController, UITableViewDataSource, UITa
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = .systemGroupedBackground
+        applyAppearance()
         
         view.addSubview(tableView)
         NSLayoutConstraint.activate([
@@ -110,6 +115,7 @@ final class HistoryViewController: UIViewController, UITableViewDataSource, UITa
         ])
         
         installHeader()
+        updateHistoryMenu()
         
         storeObserver = NotificationCenter.default.addObserver(
             forName: .historyStoreDidChange,
@@ -152,7 +158,15 @@ final class HistoryViewController: UIViewController, UITableViewDataSource, UITa
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        applyAppearance()
         installClearHistoryNavigationActionIfNeeded()
+    }
+
+    private func applyAppearance() {
+        view.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        tableView.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        tableView.tintColor = BrowserAppearance.accentColor
+        navigationController?.navigationBar.tintColor = BrowserAppearance.accentColor
     }
     
     // MARK: - View Setup
@@ -247,7 +261,165 @@ final class HistoryViewController: UIViewController, UITableViewDataSource, UITa
         }
         
         clearHistoryActionItem.tintColor = .label
+        updateHistoryMenu()
         LibraryActionButton.installNavigationAction(clearHistoryActionItem, in: navigationItem)
+    }
+
+    private func updateHistoryMenu() {
+        if #available(iOS 14.0, *) {
+            let menu = makeHistoryMenu()
+            clearHistoryActionItem.menu = menu
+            clearHistoryActionItem.target = nil
+            clearHistoryActionItem.action = nil
+            clearHistoryButton.menu = menu
+            clearHistoryButton.showsMenuAsPrimaryAction = true
+        }
+    }
+
+    @available(iOS 14.0, *)
+    private func makeHistoryMenu() -> UIMenu {
+        UIMenu(title: "", children: [
+            UIAction(title: "Clear History", image: UIImage(named: "reynard.clock.badge.xmark"), attributes: .destructive) { [weak self] _ in
+                self?.showClearHistory()
+            },
+            UIMenu(title: "", image: nil, identifier: nil, options: .displayInline, children: [
+                UIAction(title: "Import History", image: UIImage(systemName: "square.and.arrow.down")) { [weak self] _ in
+                    self?.confirmHistoryImport()
+                },
+                UIAction(title: "Export History", image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+                    self?.confirmHistoryExport()
+                },
+            ]),
+        ])
+    }
+
+    // MARK: - History Transfer
+
+    private func confirmHistoryExport() {
+        let alert = UIAlertController(
+            title: "Export History",
+            message: "This creates a local CSV file that may include private URLs and page titles.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Export", style: .default) { [weak self] _ in
+            self?.exportHistory()
+        })
+        present(alert, animated: true)
+    }
+
+    private func exportHistory() {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let items = HistoryStore.shared.currentSnapshot().items
+            let data = HistoryCSVTransfer.exportCSV(items: items)
+            let exportURL = FileManager.default.temporaryDirectory.appendingPathComponent(HistoryCSVTransfer.fileName)
+
+            do {
+                try data.write(to: exportURL, options: .atomic)
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentExportShareSheet(for: exportURL)
+                }
+            } catch {
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentTransferError(message: "Could not create the history export file.")
+                }
+            }
+        }
+    }
+
+    private func presentExportShareSheet(for url: URL) {
+        let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        controller.popoverPresentationController?.sourceView = view
+        controller.popoverPresentationController?.sourceRect = CGRect(
+            x: view.bounds.midX,
+            y: view.bounds.midY,
+            width: 1,
+            height: 1
+        )
+        present(controller, animated: true)
+    }
+
+    private func confirmHistoryImport() {
+        let alert = UIAlertController(
+            title: "Import History",
+            message: "Choose a Reynard CSV history export. Imported rows are stored locally; this is not Firefox Sync.",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Choose File", style: .default) { [weak self] _ in
+            self?.presentHistoryImporter()
+        })
+        present(alert, animated: true)
+    }
+
+    private func presentHistoryImporter() {
+        documentImportMode = .history
+        let controller = UIDocumentPickerViewController(
+            documentTypes: ["public.comma-separated-values-text", "public.text"],
+            in: .import
+        )
+        controller.delegate = self
+        controller.allowsMultipleSelection = false
+        present(controller, animated: true)
+    }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        guard documentImportMode == .history,
+              let url = urls.first else {
+            documentImportMode = nil
+            return
+        }
+
+        documentImportMode = nil
+        importHistory(from: url)
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        documentImportMode = nil
+    }
+
+    private func importHistory(from url: URL) {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let didStartAccessing = url.startAccessingSecurityScopedResource()
+            defer {
+                if didStartAccessing {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+
+            guard let data = try? Data(contentsOf: url) else {
+                DispatchQueue.main.async { [weak self] in
+                    self?.presentTransferError(message: "Could not read the selected history file.")
+                }
+                return
+            }
+
+            let importedItems = HistoryCSVTransfer.parseHistory(from: data)
+            for item in importedItems {
+                HistoryStore.shared.recordVisit(url: item.url, title: item.title, visitedAt: item.visitedAt)
+            }
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+                self?.reloadHistory()
+                self?.presentImportSummary(DataImportSummary(imported: importedItems.count, skipped: 0))
+            }
+        }
+    }
+
+    private func presentImportSummary(_ summary: DataImportSummary) {
+        let alert = UIAlertController(
+            title: "Import Complete",
+            message: "Imported \(summary.imported) history rows. Skipped \(summary.skipped).",
+            preferredStyle: .alert
+        )
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
+    }
+
+    private func presentTransferError(message: String) {
+        let alert = UIAlertController(title: "Transfer Failed", message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default))
+        present(alert, animated: true)
     }
     
     // MARK: - Loading

--- a/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Appearance/AppearancePreferencesViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Appearance/AppearancePreferencesViewController.swift
@@ -9,25 +9,40 @@ import UIKit
 
 final class AppearancePreferencesViewController: SettingsTableViewController {
     private enum Section: CaseIterable {
+        case theme
+        case accent
         case tabs
         
         var text: SettingsSectionText {
             switch self {
+            case .theme:
+                return SettingsSectionText(
+                    headerTitle: "Theme",
+                    footerTitle: "OLED Black uses true black surfaces when the interface is in dark appearance."
+                )
+            case .accent:
+                return SettingsSectionText(headerTitle: "Accent")
             case .tabs:
                 return SettingsSectionText(headerTitle: "Tabs")
             }
         }
     }
     
-    private enum Row: CaseIterable {
-        case BrowserChromePosition
+    private enum Row {
+        case theme(BrowserThemeMode)
+        case accent(BrowserAccentColor)
+        case browserChromePosition
         case landscapeTabBar
     }
     
     private let landscapeTabBarSwitch = UISwitch()
     
     private var displayedSections: [Section] {
-        return UIDevice.current.userInterfaceIdiom == .pad ? [] : Section.allCases
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            return [.theme, .accent]
+        }
+
+        return Section.allCases
     }
     
     init() {
@@ -59,7 +74,7 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
         guard displayedSections.indices.contains(section) else {
             return 0
         }
-        return Row.allCases.count
+        return rows(for: displayedSections[section]).count
     }
     
     override func sectionText(for section: Int) -> SettingsSectionText {
@@ -71,12 +86,23 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard displayedSections.indices.contains(indexPath.section),
-              Row.allCases.indices.contains(indexPath.row) else {
+              rows(for: displayedSections[indexPath.section]).indices.contains(indexPath.row) else {
             return UITableViewCell()
         }
-        
-        switch Row.allCases[indexPath.row] {
-        case .BrowserChromePosition:
+
+        switch rows(for: displayedSections[indexPath.section])[indexPath.row] {
+        case let .theme(mode):
+            let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+            cell.textLabel?.text = mode.displayName
+            cell.accessoryType = mode == Prefs.AppearanceSettings.themeMode ? .checkmark : .none
+            return cell
+        case let .accent(accent):
+            let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+            cell.textLabel?.text = accent.displayName
+            cell.imageView?.image = swatchImage(color: accent.color)
+            cell.accessoryType = accent == Prefs.AppearanceSettings.accentColor ? .checkmark : .none
+            return cell
+        case .browserChromePosition:
             let cell = BrowserChromePositionPickerCell(style: .default, reuseIdentifier: nil)
             cell.display(selectedPosition: Prefs.AppearanceSettings.addressBarPosition)
             cell.onPositionChanged = { position in
@@ -91,6 +117,25 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
             return cell
         }
     }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard displayedSections.indices.contains(indexPath.section),
+              rows(for: displayedSections[indexPath.section]).indices.contains(indexPath.row) else {
+            return
+        }
+
+        switch rows(for: displayedSections[indexPath.section])[indexPath.row] {
+        case let .theme(mode):
+            Prefs.AppearanceSettings.themeMode = mode
+            tableView.reloadSections(IndexSet(integer: indexPath.section), with: .automatic)
+        case let .accent(accent):
+            Prefs.AppearanceSettings.accentColor = accent
+            tableView.reloadSections(IndexSet(integer: indexPath.section), with: .automatic)
+        case .browserChromePosition, .landscapeTabBar:
+            return
+        }
+    }
     
     private func configureSwitch() {
         landscapeTabBarSwitch.addTarget(self, action: #selector(landscapeTabBarSwitchDidChange), for: .valueChanged)
@@ -102,5 +147,26 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
     
     @objc private func landscapeTabBarSwitchDidChange() {
         Prefs.AppearanceSettings.showsLandscapeTabBar = landscapeTabBarSwitch.isOn
+    }
+
+    private func rows(for section: Section) -> [Row] {
+        switch section {
+        case .theme:
+            return BrowserThemeMode.allCases.map(Row.theme)
+        case .accent:
+            return BrowserAccentColor.allCases.map(Row.accent)
+        case .tabs:
+            return [.browserChromePosition, .landscapeTabBar]
+        }
+    }
+
+    private func swatchImage(color: UIColor) -> UIImage {
+        let size = CGSize(width: 22, height: 22)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { _ in
+            let rect = CGRect(origin: .zero, size: size).insetBy(dx: 2, dy: 2)
+            color.setFill()
+            UIBezierPath(ovalIn: rect).fill()
+        }
     }
 }

--- a/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Appearance/AppearancePreferencesViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Appearance/AppearancePreferencesViewController.swift
@@ -8,6 +8,13 @@
 import UIKit
 
 final class AppearancePreferencesViewController: SettingsTableViewController {
+    private enum UX {
+        static let swatchSize = CGSize(width: 22, height: 22)
+        static let swatchInset: CGFloat = 2
+        static let swatchCornerRadius: CGFloat = 4
+        static let swatchStrokeWidth: CGFloat = 1
+    }
+
     private enum Section: CaseIterable {
         case theme
         case accent
@@ -21,7 +28,10 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
                     footerTitle: "OLED Black uses true black surfaces when the interface is in dark appearance."
                 )
             case .accent:
-                return SettingsSectionText(headerTitle: "Accent")
+                return SettingsSectionText(
+                    headerTitle: "Accent",
+                    footerTitle: "Custom colors accept #RRGGBB hex values and must stay visible in light, dark, and OLED Black themes."
+                )
             case .tabs:
                 return SettingsSectionText(headerTitle: "Tabs")
             }
@@ -31,6 +41,7 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
     private enum Row {
         case theme(BrowserThemeMode)
         case accent(BrowserAccentColor)
+        case customAccent
         case browserChromePosition
         case landscapeTabBar
     }
@@ -99,8 +110,20 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
         case let .accent(accent):
             let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
             cell.textLabel?.text = accent.displayName
-            cell.imageView?.image = swatchImage(color: accent.color)
+            cell.imageView?.image = swatchImage(color: accent.color, shape: .circle)
             cell.accessoryType = accent == Prefs.AppearanceSettings.accentColor ? .checkmark : .none
+            return cell
+        case .customAccent:
+            let cell = UITableViewCell(style: .subtitle, reuseIdentifier: nil)
+            let hex = Prefs.AppearanceSettings.customAccentHex
+            let isSelected = Prefs.AppearanceSettings.accentColor == .custom
+            cell.textLabel?.text = "Custom"
+            cell.detailTextLabel?.text = hex
+            cell.imageView?.image = swatchImage(color: Prefs.AppearanceSettings.customAccentColor, shape: .square)
+            cell.accessoryType = isSelected ? .checkmark : .none
+            cell.accessibilityLabel = "Custom accent color"
+            cell.accessibilityValue = "\(hex), \(isSelected ? "selected" : "not selected")"
+            cell.accessibilityHint = "Opens custom accent color options."
             return cell
         case .browserChromePosition:
             let cell = BrowserChromePositionPickerCell(style: .default, reuseIdentifier: nil)
@@ -132,6 +155,8 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
         case let .accent(accent):
             Prefs.AppearanceSettings.accentColor = accent
             tableView.reloadSections(IndexSet(integer: indexPath.section), with: .automatic)
+        case .customAccent:
+            presentCustomAccentActions(from: tableView.cellForRow(at: indexPath))
         case .browserChromePosition, .landscapeTabBar:
             return
         }
@@ -154,19 +179,167 @@ final class AppearancePreferencesViewController: SettingsTableViewController {
         case .theme:
             return BrowserThemeMode.allCases.map(Row.theme)
         case .accent:
-            return BrowserAccentColor.allCases.map(Row.accent)
+            return BrowserAccentColor.presetCases.map(Row.accent) + [.customAccent]
         case .tabs:
             return [.browserChromePosition, .landscapeTabBar]
         }
     }
 
-    private func swatchImage(color: UIColor) -> UIImage {
-        let size = CGSize(width: 22, height: 22)
+    private enum SwatchShape {
+        case circle
+        case square
+    }
+
+    private func swatchImage(color: UIColor, shape: SwatchShape) -> UIImage {
+        let size = UX.swatchSize
         let renderer = UIGraphicsImageRenderer(size: size)
         return renderer.image { _ in
-            let rect = CGRect(origin: .zero, size: size).insetBy(dx: 2, dy: 2)
+            let rect = CGRect(origin: .zero, size: size).insetBy(dx: UX.swatchInset, dy: UX.swatchInset)
+            let path: UIBezierPath
+            switch shape {
+            case .circle:
+                path = UIBezierPath(ovalIn: rect)
+            case .square:
+                path = UIBezierPath(roundedRect: rect, cornerRadius: UX.swatchCornerRadius)
+            }
             color.setFill()
-            UIBezierPath(ovalIn: rect).fill()
+            path.fill()
+            UIColor.separator.setStroke()
+            path.lineWidth = UX.swatchStrokeWidth
+            path.stroke()
         }
+    }
+
+    private func presentCustomAccentActions(from sourceView: UIView?) {
+        let hex = Prefs.AppearanceSettings.customAccentHex
+        let alert = UIAlertController(
+            title: "Custom Accent",
+            message: "Current color: \(hex)",
+            preferredStyle: .actionSheet
+        )
+
+        if #available(iOS 14.0, *) {
+            alert.addAction(UIAlertAction(title: "Choose Custom Color", style: .default) { [weak self] _ in
+                self?.presentCustomColorPicker(sourceView: sourceView)
+            })
+        }
+
+        alert.addAction(UIAlertAction(title: "Enter Hex Code", style: .default) { [weak self] _ in
+            self?.presentCustomHexEntry()
+        })
+        alert.addAction(UIAlertAction(title: "Use Current Custom Color", style: .default) { [weak self] _ in
+            self?.commitCustomAccent(hex: hex, showsError: true)
+        })
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+
+        if let popover = alert.popoverPresentationController,
+           let sourceView {
+            popover.sourceView = sourceView
+            popover.sourceRect = sourceView.bounds
+        }
+
+        present(alert, animated: true)
+    }
+
+    @available(iOS 14.0, *)
+    private func presentCustomColorPicker(sourceView: UIView?) {
+        let picker = UIColorPickerViewController()
+        picker.title = "Choose Custom Color"
+        picker.selectedColor = Prefs.AppearanceSettings.customAccentColor
+        picker.supportsAlpha = false
+        picker.delegate = self
+        picker.modalPresentationStyle = .popover
+
+        if let popover = picker.popoverPresentationController,
+           let sourceView {
+            popover.sourceView = sourceView
+            popover.sourceRect = sourceView.bounds
+        }
+
+        present(picker, animated: true)
+    }
+
+    private func presentCustomHexEntry() {
+        let alert = UIAlertController(
+            title: "Custom Accent Hex",
+            message: "Enter a 6-digit color value.",
+            preferredStyle: .alert
+        )
+        alert.addTextField { textField in
+            textField.text = Prefs.AppearanceSettings.customAccentHex
+            textField.placeholder = BrowserAccentColor.defaultCustomHex
+            textField.keyboardType = .asciiCapable
+            textField.autocapitalizationType = .allCharacters
+            textField.autocorrectionType = .no
+            textField.clearButtonMode = .whileEditing
+            textField.accessibilityLabel = "Custom accent hex code"
+        }
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        alert.addAction(UIAlertAction(title: "Apply", style: .default) { [weak self, weak alert] _ in
+            let hex = alert?.textFields?.first?.text ?? ""
+            self?.commitCustomAccent(hex: hex, showsError: true)
+        })
+        present(alert, animated: true)
+    }
+
+    @discardableResult
+    private func commitCustomAccent(hex: String, showsError: Bool) -> Bool {
+        guard let normalizedHex = BrowserAccentColor.normalizedCustomHex(hex) else {
+            showCustomAccentError("Enter a 6-digit hex color such as #007AFF.", showsError: showsError)
+            return false
+        }
+
+        let validationMessage = BrowserAccentColor.validationMessage(forCustomHex: normalizedHex)
+        guard validationMessage == nil else {
+            showCustomAccentError(validationMessage, showsError: showsError)
+            return false
+        }
+
+        Prefs.AppearanceSettings.customAccentHex = normalizedHex
+        Prefs.AppearanceSettings.accentColor = .custom
+        reloadAccentSection()
+        return true
+    }
+
+    @discardableResult
+    private func commitCustomAccent(color: UIColor, showsError: Bool) -> Bool {
+        let validationMessage = BrowserAccentColor.validationMessage(forCustomColor: color)
+        guard validationMessage == nil else {
+            showCustomAccentError(validationMessage, showsError: showsError)
+            return false
+        }
+
+        Prefs.AppearanceSettings.customAccentHex = color.toHexString().uppercased()
+        Prefs.AppearanceSettings.accentColor = .custom
+        reloadAccentSection()
+        return true
+    }
+
+    private func showCustomAccentError(_ message: String?, showsError: Bool) {
+        guard showsError else { return }
+        AlertPresenter.show(
+            title: "Invalid Accent Color",
+            message: message ?? "Choose a different custom accent color."
+        )
+    }
+
+    private func reloadAccentSection() {
+        guard let section = displayedSections.firstIndex(of: .accent) else {
+            tableView.reloadData()
+            return
+        }
+
+        tableView.reloadSections(IndexSet(integer: section), with: .automatic)
+    }
+}
+
+@available(iOS 14.0, *)
+extension AppearancePreferencesViewController: UIColorPickerViewControllerDelegate {
+    func colorPickerViewControllerDidSelectColor(_ viewController: UIColorPickerViewController) {
+        commitCustomAccent(color: viewController.selectedColor, showsError: false)
+    }
+
+    func colorPickerViewControllerDidFinish(_ viewController: UIColorPickerViewController) {
+        commitCustomAccent(color: viewController.selectedColor, showsError: true)
     }
 }

--- a/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Browsing/BrowsingPreferencesViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Browsing/BrowsingPreferencesViewController.swift
@@ -10,19 +10,29 @@ import UIKit
 final class BrowsingPreferencesViewController: SettingsTableViewController {
     private enum Section: CaseIterable {
         case desktopWebsite
+        case pageZoom
         
         var text: SettingsSectionText {
             switch self {
             case .desktopWebsite:
                 return SettingsSectionText(headerTitle: "Request Desktop Website On")
+            case .pageZoom:
+                return SettingsSectionText(
+                    headerTitle: "Page Zoom",
+                    footerTitle: "Sites use the default zoom unless a site-specific value is set from the page menu."
+                )
             }
         }
     }
     
-    private enum Row: CaseIterable {
+    private enum DesktopWebsiteRow: CaseIterable {
         case allWebsites
     }
     
+    private enum PageZoomRow: CaseIterable {
+        case defaultZoom
+    }
+
     private let requestDesktopWebsiteSwitch = UISwitch()
     
     init() {
@@ -43,6 +53,7 @@ final class BrowsingPreferencesViewController: SettingsTableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         refreshDisplayedState()
+        tableView.reloadData()
     }
     
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -56,7 +67,9 @@ final class BrowsingPreferencesViewController: SettingsTableViewController {
         
         switch Section.allCases[section] {
         case .desktopWebsite:
-            return Row.allCases.count
+            return DesktopWebsiteRow.allCases.count
+        case .pageZoom:
+            return PageZoomRow.allCases.count
         }
     }
     
@@ -68,18 +81,50 @@ final class BrowsingPreferencesViewController: SettingsTableViewController {
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard Section.allCases.indices.contains(indexPath.section),
-              Row.allCases.indices.contains(indexPath.row) else {
+        guard Section.allCases.indices.contains(indexPath.section) else {
             return UITableViewCell()
         }
         
-        switch Row.allCases[indexPath.row] {
-        case .allWebsites:
+        switch Section.allCases[indexPath.section] {
+        case .desktopWebsite:
+            guard DesktopWebsiteRow.allCases.indices.contains(indexPath.row) else {
+                return UITableViewCell()
+            }
             let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
             cell.selectionStyle = .none
             cell.textLabel?.text = "All Website"
             cell.accessoryView = requestDesktopWebsiteSwitch
             return cell
+        case .pageZoom:
+            guard PageZoomRow.allCases.indices.contains(indexPath.row) else {
+                return UITableViewCell()
+            }
+            let cell = UITableViewCell(style: .value1, reuseIdentifier: nil)
+            cell.textLabel?.text = "Default Page Zoom"
+            cell.detailTextLabel?.text = PageZoomLevel.displayTitle(for: PageZoomStore.shared.defaultPercent)
+            cell.detailTextLabel?.textColor = .secondaryLabel
+            cell.accessoryType = .disclosureIndicator
+            return cell
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        defer { tableView.deselectRow(at: indexPath, animated: true) }
+        guard Section.allCases.indices.contains(indexPath.section) else {
+            return
+        }
+
+        switch Section.allCases[indexPath.section] {
+        case .desktopWebsite:
+            guard DesktopWebsiteRow.allCases.indices.contains(indexPath.row) else {
+                return
+            }
+            return
+        case .pageZoom:
+            guard PageZoomRow.allCases.indices.contains(indexPath.row) else {
+                return
+            }
+            navigationController?.pushViewController(PageZoomPreferencesViewController(), animated: true)
         }
     }
     

--- a/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Browsing/PageZoomPreferencesViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Browsing/PageZoomPreferencesViewController.swift
@@ -1,0 +1,73 @@
+//
+//  PageZoomPreferencesViewController.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import UIKit
+
+final class PageZoomPreferencesViewController: SettingsTableViewController {
+    private enum Section: CaseIterable {
+        case defaultZoom
+
+        var text: SettingsSectionText {
+            return SettingsSectionText(
+                headerTitle: "Default Zoom",
+                footerTitle: "Sites use this zoom unless a site-specific Page Zoom value is set from the page menu."
+            )
+        }
+    }
+
+    init() {
+        super.init(style: .insetGrouped)
+        title = "Page Zoom"
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        Section.allCases.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard Section.allCases.indices.contains(section) else {
+            return 0
+        }
+        return PageZoomLevel.allowedPercents.count
+    }
+
+    override func sectionText(for section: Int) -> SettingsSectionText {
+        guard Section.allCases.indices.contains(section) else {
+            return SettingsSectionText()
+        }
+        return Section.allCases[section].text
+    }
+
+    override func tableView(
+        _ tableView: UITableView,
+        cellForRowAt indexPath: IndexPath
+    ) -> UITableViewCell {
+        guard PageZoomLevel.allowedPercents.indices.contains(indexPath.row) else {
+            return UITableViewCell()
+        }
+
+        let percent = PageZoomLevel.allowedPercents[indexPath.row]
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.textLabel?.text = PageZoomLevel.displayTitle(for: percent)
+        cell.accessoryType = percent == PageZoomStore.shared.defaultPercent ? .checkmark : .none
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        defer { tableView.deselectRow(at: indexPath, animated: true) }
+        guard PageZoomLevel.allowedPercents.indices.contains(indexPath.row) else {
+            return
+        }
+
+        PageZoomStore.shared.defaultPercent = PageZoomLevel.allowedPercents[indexPath.row]
+        tableView.reloadSections(IndexSet(integer: indexPath.section), with: .automatic)
+    }
+}

--- a/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Search/SearchPreferencesViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Settings/Sections/General/Search/SearchPreferencesViewController.swift
@@ -12,13 +12,18 @@ final class SearchPreferencesViewController: SettingsTableViewController {
         case search
         
         var text: SettingsSectionText {
-            return SettingsSectionText()
+            return SettingsSectionText(
+                footerTitle: "Address bar suggestions use local bookmarks, history, tabs, and common domains. Search-engine suggestions are sent only when enabled."
+            )
         }
     }
     
     private enum Row: CaseIterable {
         case searchEngine
+        case searchSuggestions
     }
+
+    private let searchSuggestionsSwitch = UISwitch()
     
     init() {
         super.init(style: .insetGrouped)
@@ -31,6 +36,7 @@ final class SearchPreferencesViewController: SettingsTableViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        refreshDisplayedState()
         tableView.reloadData()
     }
     
@@ -70,6 +76,12 @@ final class SearchPreferencesViewController: SettingsTableViewController {
             cell.detailTextLabel?.textColor = .secondaryLabel
             cell.accessoryType = .disclosureIndicator
             return cell
+        case .searchSuggestions:
+            let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+            cell.textLabel?.text = "Search Suggestions"
+            cell.selectionStyle = .none
+            cell.accessoryView = searchSuggestionsSwitch
+            return cell
         }
     }
     
@@ -83,7 +95,22 @@ final class SearchPreferencesViewController: SettingsTableViewController {
         switch Row.allCases[indexPath.row] {
         case .searchEngine:
             navigationController?.pushViewController(SearchEnginePreferencesViewController(), animated: true)
+        case .searchSuggestions:
+            return
         }
     }
-    
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        searchSuggestionsSwitch.addTarget(self, action: #selector(searchSuggestionsSwitchDidChange), for: .valueChanged)
+        refreshDisplayedState()
+    }
+
+    private func refreshDisplayedState() {
+        searchSuggestionsSwitch.isOn = Prefs.SearchSettings.searchSuggestionsEnabled
+    }
+
+    @objc private func searchSuggestionsSwitchDidChange() {
+        Prefs.SearchSettings.searchSuggestionsEnabled = searchSuggestionsSwitch.isOn
+    }
 }

--- a/browser/Reynard/Client/Interface/Library/Settings/SettingsTableViewController.swift
+++ b/browser/Reynard/Client/Interface/Library/Settings/SettingsTableViewController.swift
@@ -15,6 +15,17 @@ class SettingsTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureTableView()
+        applyAppearance()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(appearancePreferencesDidChange),
+            name: .appearancePreferencesDidChange,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
@@ -36,5 +47,17 @@ class SettingsTableViewController: UITableViewController {
         if #available(iOS 15.0, *) {
             tableView.sectionHeaderTopPadding = UX.sectionHeaderTopPadding
         }
+    }
+
+    @objc private func appearancePreferencesDidChange() {
+        applyAppearance()
+        tableView.reloadData()
+    }
+
+    private func applyAppearance() {
+        view.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        tableView.backgroundColor = BrowserAppearance.groupedBackgroundColor
+        tableView.tintColor = BrowserAppearance.accentColor
+        navigationController?.navigationBar.tintColor = BrowserAppearance.accentColor
     }
 }

--- a/browser/Reynard/Client/Interface/Search/SearchViewController.swift
+++ b/browser/Reynard/Client/Interface/Search/SearchViewController.swift
@@ -70,7 +70,7 @@ final class SearchViewController: UIViewController, UITableViewDataSource, UITab
         return view
     }()
     
-    private lazy var completionsHeaderView = makeSectionHeaderView(title: "\(viewModel.completionProvider.name) Suggestions")
+    private lazy var completionsHeaderView = makeSectionHeaderView(title: viewModel.completionSectionTitle)
     private lazy var userDataHeaderView = makeSectionHeaderView(title: "Bookmarks, History, and Tabs")
     
     // MARK: - Lifecycle

--- a/browser/Reynard/Client/Interface/Search/SearchViewModel.swift
+++ b/browser/Reynard/Client/Interface/Search/SearchViewModel.swift
@@ -24,11 +24,15 @@ struct SearchResults {
 final class SearchViewModel {
     var resultsDidChange: ((SearchResults) -> Void)?
     let completionProvider: SearchCompletion.Provider
+    var completionSectionTitle: String {
+        Prefs.SearchSettings.searchSuggestionsEnabled ? "\(completionProvider.name) Suggestions" : "Local Suggestions"
+    }
     
     private let userDataSearch: UserDataSearch
     private let searchCompletion: SearchCompletion
     private var requestID = 0
     private var completionTask: URLSessionDataTask?
+    private var completionWorkItem: DispatchWorkItem?
     private var results = SearchResults.empty
     
     init(
@@ -42,12 +46,15 @@ final class SearchViewModel {
     
     deinit {
         completionTask?.cancel()
+        completionWorkItem?.cancel()
     }
     
     func clear() {
         requestID += 1
         completionTask?.cancel()
+        completionWorkItem?.cancel()
         completionTask = nil
+        completionWorkItem = nil
         results = .empty
         resultsDidChange?(.empty)
     }
@@ -65,7 +72,9 @@ final class SearchViewModel {
         requestID += 1
         let activeRequestID = requestID
         completionTask?.cancel()
+        completionWorkItem?.cancel()
         results.query = query
+        results.completions = LocalURLCompletion.completions(for: query)
         resultsDidChange?(results)
         
         DispatchQueue.global(qos: .userInitiated).async { [weak self] in
@@ -90,16 +99,47 @@ final class SearchViewModel {
             }
         }
         
-        completionTask = searchCompletion.fetchCompletions(for: query) { [weak self] completions in
-            DispatchQueue.main.async {
-                guard let self,
-                      activeRequestID == self.requestID else {
-                    return
+        guard Prefs.SearchSettings.searchSuggestionsEnabled else {
+            completionTask = nil
+            completionWorkItem = nil
+            return
+        }
+
+        let workItem = DispatchWorkItem { [weak self] in
+            guard let self,
+                  activeRequestID == self.requestID else {
+                return
+            }
+
+            self.completionTask = self.searchCompletion.fetchCompletions(for: query) { [weak self] completions in
+                DispatchQueue.main.async {
+                    guard let self,
+                          activeRequestID == self.requestID else {
+                        return
+                    }
+
+                    self.results.completions = Self.mergedCompletions(
+                        local: LocalURLCompletion.completions(for: query),
+                        remote: completions
+                    )
+                    self.resultsDidChange?(self.results)
                 }
-                
-                self.results.completions = completions
-                self.resultsDidChange?(self.results)
             }
         }
+        completionWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.18, execute: workItem)
+    }
+
+    private static func mergedCompletions(local: [String], remote: [String]) -> [String] {
+        var seen = Set<String>()
+        var merged: [String] = []
+        for completion in local + remote {
+            let key = completion.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !key.isEmpty, seen.insert(key).inserted else {
+                continue
+            }
+            merged.append(completion)
+        }
+        return merged
     }
 }

--- a/browser/Reynard/Client/Preferences/BrowserPreferences.swift
+++ b/browser/Reynard/Client/Preferences/BrowserPreferences.swift
@@ -34,6 +34,7 @@ final class BrowserPreferences {
             // Search
             key("SearchSettings", "searchEngine"): SearchEngine.google.rawValue,
             key("SearchSettings", "customSearchTemplate"): "",
+            key("SearchSettings", "searchSuggestionsEnabled"): false,
             
             // JIT
             key("JITSettings", "isJITEnabled"): false,
@@ -50,6 +51,8 @@ final class BrowserPreferences {
             // Appearance
             key("AppearanceSettings", "addressBarPosition"): BrowserChromePosition.bottom.rawValue,
             key("AppearanceSettings", "showsLandscapeTabBar"): true,
+            key("AppearanceSettings", "themeMode"): BrowserThemeMode.system.rawValue,
+            key("AppearanceSettings", "accentColor"): BrowserAccentColor.highContrast.rawValue,
             
             // Bookmarks
             key("BookmarkSettings", "placeFoldersOnTop"): true,
@@ -121,6 +124,15 @@ final class BrowserPreferences {
             }
             set {
                 prefs.set(newValue.trimmingCharacters(in: .whitespacesAndNewlines), forSetting: "SearchSettings", key: "customSearchTemplate")
+            }
+        }
+
+        static var searchSuggestionsEnabled: Bool {
+            get {
+                prefs.bool(forSetting: "SearchSettings", key: "searchSuggestionsEnabled")
+            }
+            set {
+                prefs.set(newValue, forSetting: "SearchSettings", key: "searchSuggestionsEnabled")
             }
         }
     }
@@ -330,6 +342,28 @@ final class BrowserPreferences {
             set {
                 prefs.set(newValue, forSetting: "AppearanceSettings", key: "showsLandscapeTabBar")
                 NotificationCenter.default.post(name: .landscapeTabBarDidChange, object: nil)
+            }
+        }
+
+        static var themeMode: BrowserThemeMode {
+            get {
+                let rawValue = prefs.string(forSetting: "AppearanceSettings", key: "themeMode") ?? BrowserThemeMode.system.rawValue
+                return BrowserThemeMode(rawValue: rawValue) ?? .system
+            }
+            set {
+                prefs.set(newValue.rawValue, forSetting: "AppearanceSettings", key: "themeMode")
+                NotificationCenter.default.post(name: .appearancePreferencesDidChange, object: nil)
+            }
+        }
+
+        static var accentColor: BrowserAccentColor {
+            get {
+                let rawValue = prefs.string(forSetting: "AppearanceSettings", key: "accentColor") ?? BrowserAccentColor.highContrast.rawValue
+                return BrowserAccentColor(rawValue: rawValue) ?? .highContrast
+            }
+            set {
+                prefs.set(newValue.rawValue, forSetting: "AppearanceSettings", key: "accentColor")
+                NotificationCenter.default.post(name: .appearancePreferencesDidChange, object: nil)
             }
         }
     }

--- a/browser/Reynard/Client/Preferences/BrowserPreferences.swift
+++ b/browser/Reynard/Client/Preferences/BrowserPreferences.swift
@@ -53,6 +53,7 @@ final class BrowserPreferences {
             key("AppearanceSettings", "showsLandscapeTabBar"): true,
             key("AppearanceSettings", "themeMode"): BrowserThemeMode.system.rawValue,
             key("AppearanceSettings", "accentColor"): BrowserAccentColor.highContrast.rawValue,
+            key("AppearanceSettings", "customAccentHex"): BrowserAccentColor.defaultCustomHex,
             
             // Bookmarks
             key("BookmarkSettings", "placeFoldersOnTop"): true,
@@ -365,6 +366,26 @@ final class BrowserPreferences {
                 prefs.set(newValue.rawValue, forSetting: "AppearanceSettings", key: "accentColor")
                 NotificationCenter.default.post(name: .appearancePreferencesDidChange, object: nil)
             }
+        }
+
+        static var customAccentHex: String {
+            get {
+                let rawValue = prefs.string(forSetting: "AppearanceSettings", key: "customAccentHex")
+                ?? BrowserAccentColor.defaultCustomHex
+                return BrowserAccentColor.normalizedCustomHex(rawValue) ?? BrowserAccentColor.defaultCustomHex
+            }
+            set {
+                guard let normalizedHex = BrowserAccentColor.normalizedCustomHex(newValue) else {
+                    return
+                }
+
+                prefs.set(normalizedHex, forSetting: "AppearanceSettings", key: "customAccentHex")
+                NotificationCenter.default.post(name: .appearancePreferencesDidChange, object: nil)
+            }
+        }
+
+        static var customAccentColor: UIColor {
+            UIColor(hexString: customAccentHex) ?? UIColor(hexString: BrowserAccentColor.defaultCustomHex) ?? .systemBlue
         }
     }
     

--- a/browser/Reynard/Client/Preferences/BrowserPreferences.swift
+++ b/browser/Reynard/Client/Preferences/BrowserPreferences.swift
@@ -44,6 +44,8 @@ final class BrowserPreferences {
             
             // Browsing
             key("BrowsingSettings", "requestDesktopWebsite"): UIDevice.current.userInterfaceIdiom == .pad,
+            key("BrowsingSettings", "defaultPageZoomPercent"): PageZoomLevel.defaultPercent,
+            key("BrowsingSettings", "pageZoomOverrides"): Data(),
             
             // Appearance
             key("AppearanceSettings", "addressBarPosition"): BrowserChromePosition.bottom.rawValue,
@@ -81,6 +83,10 @@ final class BrowserPreferences {
         UserDefaults.standard.data(forKey: key(setting, name))
     }
     
+    func integer(forSetting setting: String, key name: String) -> Int {
+        UserDefaults.standard.integer(forKey: key(setting, name))
+    }
+
     func set(_ value: Bool, forSetting setting: String, key name: String) {
         UserDefaults.standard.set(value, forKey: key(setting, name))
     }
@@ -93,6 +99,10 @@ final class BrowserPreferences {
         UserDefaults.standard.set(value, forKey: key(setting, name))
     }
     
+    func set(_ value: Int, forSetting setting: String, key name: String) {
+        UserDefaults.standard.set(value, forKey: key(setting, name))
+    }
+
     // MARK: - Search
     struct SearchSettings {
         static var searchEngine: SearchEngine {
@@ -123,6 +133,38 @@ final class BrowserPreferences {
             }
             set {
                 prefs.set(newValue, forSetting: "BrowsingSettings", key: "requestDesktopWebsite")
+            }
+        }
+
+        static var defaultPageZoomPercent: Int {
+            get {
+                PageZoomLevel.normalizedPercent(
+                    prefs.integer(forSetting: "BrowsingSettings", key: "defaultPageZoomPercent")
+                )
+            }
+            set {
+                prefs.set(
+                    PageZoomLevel.normalizedPercent(newValue),
+                    forSetting: "BrowsingSettings",
+                    key: "defaultPageZoomPercent"
+                )
+                NotificationCenter.default.post(name: .pageZoomPreferencesDidChange, object: nil)
+            }
+        }
+
+        static var pageZoomOverrides: [String: Int] {
+            get {
+                guard let data = prefs.data(forSetting: "BrowsingSettings", key: "pageZoomOverrides"),
+                      !data.isEmpty,
+                      let overrides = try? JSONDecoder().decode([String: Int].self, from: data) else {
+                    return [:]
+                }
+                return overrides
+            }
+            set {
+                let data = try? JSONEncoder().encode(newValue)
+                prefs.set(data, forSetting: "BrowsingSettings", key: "pageZoomOverrides")
+                NotificationCenter.default.post(name: .pageZoomPreferencesDidChange, object: nil)
             }
         }
     }

--- a/browser/Reynard/Client/Search/LocalURLCompletion.swift
+++ b/browser/Reynard/Client/Search/LocalURLCompletion.swift
@@ -1,0 +1,50 @@
+//
+//  LocalURLCompletion.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import Foundation
+
+enum LocalURLCompletion {
+    private static let commonDomains = [
+        "apple.com",
+        "google.com",
+        "youtube.com",
+        "github.com",
+        "reddit.com",
+        "wikipedia.org",
+        "chatgpt.com",
+        "mozilla.org",
+        "news.ycombinator.com",
+        "stackoverflow.com",
+    ]
+
+    static func completions(for query: String, limit: Int = 5) -> [String] {
+        let normalizedQuery = URLUtils.normalizedURLMatchString(from: query.trimmingCharacters(in: .whitespacesAndNewlines))
+        guard normalizedQuery.count >= 2 else {
+            return []
+        }
+
+        var completions: [String] = []
+        for domain in commonDomains where domain.hasPrefix(normalizedQuery) {
+            completions.append(domain)
+            if completions.count >= limit {
+                return completions
+            }
+        }
+
+        guard !normalizedQuery.contains(" "),
+              !normalizedQuery.contains("."),
+              normalizedQuery.count >= 3 else {
+            return completions
+        }
+
+        let fallback = "\(normalizedQuery).com"
+        if !commonDomains.contains(fallback) {
+            completions.append(fallback)
+        }
+        return Array(completions.prefix(limit))
+    }
+}

--- a/browser/Reynard/Client/Search/UserDataSearch.swift
+++ b/browser/Reynard/Client/Search/UserDataSearch.swift
@@ -78,7 +78,7 @@ final class UserDataSearch {
             limit: limit,
             isPrivate: activeTabMode == .private
         ).filter { $0.id != excludingTabID }
-        let historyMatches = historyStore.search(matching: query, limit: limit).items
+        let historyMatches = activeTabMode == .private ? [] : historyStore.search(matching: query, limit: limit).items
         let bookmarkMatches = bookmarkStore.bookmarks(matchingPrefix: query, limit: limit)
         
         var bestMatchCandidates: [UserDataSearchResult] = []
@@ -107,7 +107,7 @@ final class UserDataSearch {
             limit: limit,
             isPrivate: activeTabMode == .private
         ).filter { $0.id != excludingTabID }
-        let historyMatches = historyStore.search(matching: query, limit: limit).items
+        let historyMatches = activeTabMode == .private ? [] : historyStore.search(matching: query, limit: limit).items
         let bookmarkMatches = bookmarkStore.bookmarks(matching: query, limit: limit)
         
         var matches: [UserDataSearchResult] = []

--- a/browser/Reynard/Client/SessionManagement/Settings/PageZoomLevel.swift
+++ b/browser/Reynard/Client/SessionManagement/Settings/PageZoomLevel.swift
@@ -25,6 +25,21 @@ enum PageZoomLevel {
         "\(normalizedPercent(percent))%"
     }
 
+    static func sliderIndex(for percent: Int) -> Int {
+        let normalized = normalizedPercent(percent)
+        return allowedPercents.firstIndex(of: normalized) ?? allowedPercents.firstIndex(of: defaultPercent) ?? 0
+    }
+
+    static func percent(forSliderValue value: Float) -> Int {
+        guard !allowedPercents.isEmpty else {
+            return defaultPercent
+        }
+
+        let roundedIndex = Int(value.rounded())
+        let clampedIndex = max(0, min(roundedIndex, allowedPercents.count - 1))
+        return allowedPercents[clampedIndex]
+    }
+
     static func lowerPercent(than percent: Int) -> Int? {
         allowedPercents.last { $0 < normalizedPercent(percent) }
     }

--- a/browser/Reynard/Client/SessionManagement/Settings/PageZoomLevel.swift
+++ b/browser/Reynard/Client/SessionManagement/Settings/PageZoomLevel.swift
@@ -1,0 +1,35 @@
+//
+//  PageZoomLevel.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import Foundation
+
+enum PageZoomLevel {
+    static let defaultPercent = 100
+    static let allowedPercents = [50, 75, 85, 100, 115, 125, 150, 175, 200, 250, 300]
+
+    static func normalizedPercent(_ percent: Int) -> Int {
+        allowedPercents.min { first, second in
+            abs(first - percent) < abs(second - percent)
+        } ?? defaultPercent
+    }
+
+    static func scale(for percent: Int) -> Double {
+        Double(normalizedPercent(percent)) / 100
+    }
+
+    static func displayTitle(for percent: Int) -> String {
+        "\(normalizedPercent(percent))%"
+    }
+
+    static func lowerPercent(than percent: Int) -> Int? {
+        allowedPercents.last { $0 < normalizedPercent(percent) }
+    }
+
+    static func higherPercent(than percent: Int) -> Int? {
+        allowedPercents.first { $0 > normalizedPercent(percent) }
+    }
+}

--- a/browser/Reynard/Client/SessionManagement/Settings/PageZoomStore.swift
+++ b/browser/Reynard/Client/SessionManagement/Settings/PageZoomStore.swift
@@ -1,0 +1,85 @@
+//
+//  PageZoomStore.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import Foundation
+
+final class PageZoomStore {
+    static let shared = PageZoomStore()
+
+    private init() {}
+
+    var defaultPercent: Int {
+        get {
+            PageZoomLevel.normalizedPercent(Prefs.BrowsingSettings.defaultPageZoomPercent)
+        }
+        set {
+            Prefs.BrowsingSettings.defaultPageZoomPercent = PageZoomLevel.normalizedPercent(newValue)
+        }
+    }
+
+    func zoomPercent(for url: String?) -> Int {
+        guard let url,
+              let host = DomainMatcher.host(from: url),
+              let override = overrideMatch(for: host)?.percent else {
+            return defaultPercent
+        }
+        return override
+    }
+
+    func zoomScale(for url: String?) -> Double {
+        PageZoomLevel.scale(for: zoomPercent(for: url))
+    }
+
+    func hasOverride(for url: String?) -> Bool {
+        guard let url,
+              let host = DomainMatcher.host(from: url) else {
+            return false
+        }
+        return overrideMatch(for: host) != nil
+    }
+
+    func setOverridePercent(_ percent: Int, for url: String) {
+        guard let host = DomainMatcher.host(from: url) else {
+            return
+        }
+
+        var overrides = Prefs.BrowsingSettings.pageZoomOverrides
+        overrides[host] = PageZoomLevel.normalizedPercent(percent)
+        Prefs.BrowsingSettings.pageZoomOverrides = overrides
+    }
+
+    func resetOverride(for url: String) {
+        guard let host = DomainMatcher.host(from: url),
+              let matchedDomain = overrideMatch(for: host)?.domain else {
+            return
+        }
+
+        var overrides = Prefs.BrowsingSettings.pageZoomOverrides
+        overrides.removeValue(forKey: matchedDomain)
+        Prefs.BrowsingSettings.pageZoomOverrides = overrides
+    }
+
+    func lowerPercent(for url: String?) -> Int? {
+        PageZoomLevel.lowerPercent(than: zoomPercent(for: url))
+    }
+
+    func higherPercent(for url: String?) -> Int? {
+        PageZoomLevel.higherPercent(than: zoomPercent(for: url))
+    }
+
+    private func overrideMatch(for host: String) -> (domain: String, percent: Int)? {
+        let overrides = Prefs.BrowsingSettings.pageZoomOverrides
+        if let exact = overrides[host] {
+            return (host, PageZoomLevel.normalizedPercent(exact))
+        }
+
+        return overrides
+            .sorted { $0.key.count > $1.key.count }
+            .first { DomainMatcher.matches(host: host, domain: $0.key) }
+            .map { ($0.key, PageZoomLevel.normalizedPercent($0.value)) }
+    }
+}

--- a/browser/Reynard/Client/SessionManagement/Settings/SessionSettingsManager.swift
+++ b/browser/Reynard/Client/SessionManagement/Settings/SessionSettingsManager.swift
@@ -16,13 +16,16 @@ final class SessionSettingsManager {
     
     private let websiteMode: WebsiteModePolicy
     private let userAgentPolicy: UserAgentPolicy
+    private let pageZoomStore: PageZoomStore
     
     init(
         websiteMode: WebsiteModePolicy = WebsiteModePolicy(),
-        userAgentPolicy: UserAgentPolicy = UserAgentPolicy()
+        userAgentPolicy: UserAgentPolicy = UserAgentPolicy(),
+        pageZoomStore: PageZoomStore = .shared
     ) {
         self.websiteMode = websiteMode
         self.userAgentPolicy = userAgentPolicy
+        self.pageZoomStore = pageZoomStore
     }
     
     func settings(for url: String, tabID: UUID?) -> GeckoSessionSettings {
@@ -36,7 +39,8 @@ final class SessionSettingsManager {
         return GeckoSessionSettings(
             userAgentOverride: userAgent.override,
             userAgentMode: mode,
-            viewportMode: mode
+            viewportMode: mode,
+            pageZoom: pageZoomStore.zoomScale(for: url)
         )
     }
     

--- a/browser/Reynard/Client/Storage/BrowsingDataTransfer.swift
+++ b/browser/Reynard/Client/Storage/BrowsingDataTransfer.swift
@@ -1,0 +1,241 @@
+//
+//  BrowsingDataTransfer.swift
+//  Reynard
+//
+//  Created by Reynard on 23/6/26.
+//
+
+import Foundation
+
+struct BookmarkImportItem: Hashable {
+    let title: String
+    let url: URL
+}
+
+struct HistoryImportItem: Hashable {
+    let title: String
+    let url: URL
+    let visitedAt: Date
+}
+
+struct DataImportSummary {
+    let imported: Int
+    let skipped: Int
+}
+
+enum BookmarkHTMLTransfer {
+    static let fileName = "Reynard-Bookmarks.html"
+
+    static func exportHTML(bookmarks: [BookmarkSnapshot]) -> Data {
+        let lines = bookmarks.map { bookmark in
+            let title = escapeHTML(bookmark.title)
+            let url = escapeHTML(bookmark.url.absoluteString)
+            let added = Int(bookmark.dateAdded.timeIntervalSince1970)
+            return "<DT><A HREF=\"\(url)\" ADD_DATE=\"\(added)\">\(title)</A>"
+        }
+        let html = """
+        <!DOCTYPE NETSCAPE-Bookmark-file-1>
+        <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+        <TITLE>Bookmarks</TITLE>
+        <H1>Bookmarks</H1>
+        <DL><p>
+        \(lines.joined(separator: "\n"))
+        </DL><p>
+        """
+        return Data(html.utf8)
+    }
+
+    static func parseBookmarks(from data: Data) -> [BookmarkImportItem] {
+        guard let text = decodeText(data) else {
+            return []
+        }
+
+        let pattern = #"<A\s+[^>]*HREF\s*=\s*(["'])(.*?)\1[^>]*>(.*?)</A>"#
+        guard let expression = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive, .dotMatchesLineSeparators]) else {
+            return []
+        }
+
+        let nsText = text as NSString
+        let range = NSRange(location: 0, length: nsText.length)
+        return expression.matches(in: text, range: range).compactMap { match in
+            guard match.numberOfRanges >= 4 else {
+                return nil
+            }
+
+            let rawURL = unescapeHTML(nsText.substring(with: match.range(at: 2)))
+            let rawTitle = stripHTML(unescapeHTML(nsText.substring(with: match.range(at: 3))))
+            guard let url = URL(string: rawURL.trimmingCharacters(in: .whitespacesAndNewlines)),
+                  URLUtils.isAbsoluteURL(url) else {
+                return nil
+            }
+
+            let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            return BookmarkImportItem(
+                title: title.isEmpty ? url.host ?? url.absoluteString : title,
+                url: url
+            )
+        }
+    }
+}
+
+enum HistoryCSVTransfer {
+    static let fileName = "Reynard-History.csv"
+
+    private static let formatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    static func exportCSV(items: [HistorySiteSnapshot]) -> Data {
+        let rows = [["Title", "URL", "Last Visited"]] + items.map { item in
+            [
+                item.title,
+                item.url.absoluteString,
+                formatter.string(from: item.lastVisitedAt),
+            ]
+        }
+        let csv = rows.map { row in
+            row.map(escapeCSV).joined(separator: ",")
+        }.joined(separator: "\n")
+        return Data(csv.utf8)
+    }
+
+    static func parseHistory(from data: Data) -> [HistoryImportItem] {
+        guard let text = decodeText(data) else {
+            return []
+        }
+
+        let records = parseCSVRecords(text)
+        guard !records.isEmpty else {
+            return []
+        }
+
+        let dataRows: ArraySlice<[String]>
+        if let firstRow = records.first,
+           firstRow.contains(where: { $0.caseInsensitiveCompare("URL") == .orderedSame }) {
+            dataRows = records.dropFirst()
+        } else {
+            dataRows = records[...]
+        }
+
+        return dataRows.compactMap { row in
+            guard row.count >= 2,
+                  let url = URL(string: row[1].trimmingCharacters(in: .whitespacesAndNewlines)),
+                  URLUtils.isWebURL(url) else {
+                return nil
+            }
+
+            let title = row[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            let visitedAt: Date
+            if row.count >= 3,
+               let parsedDate = formatter.date(from: row[2].trimmingCharacters(in: .whitespacesAndNewlines)) {
+                visitedAt = parsedDate
+            } else {
+                visitedAt = Date()
+            }
+
+            return HistoryImportItem(
+                title: title.isEmpty ? url.host ?? url.absoluteString : title,
+                url: url,
+                visitedAt: visitedAt
+            )
+        }
+    }
+
+    private static func escapeCSV(_ value: String) -> String {
+        let escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
+    }
+
+    private static func parseCSVRecords(_ text: String) -> [[String]] {
+        var rows: [[String]] = []
+        var row: [String] = []
+        var field = ""
+        var isQuoted = false
+        var iterator = text.makeIterator()
+
+        while let character = iterator.next() {
+            if character == "\"" {
+                if isQuoted, let next = iterator.next() {
+                    if next == "\"" {
+                        field.append("\"")
+                    } else {
+                        isQuoted = false
+                        handleCSVDelimiter(next, row: &row, rows: &rows, field: &field, isQuoted: isQuoted)
+                    }
+                } else {
+                    isQuoted.toggle()
+                }
+                continue
+            }
+
+            handleCSVDelimiter(character, row: &row, rows: &rows, field: &field, isQuoted: isQuoted)
+        }
+
+        row.append(field)
+        if row.contains(where: { !$0.isEmpty }) {
+            rows.append(row)
+        }
+        return rows
+    }
+
+    private static func handleCSVDelimiter(
+        _ character: Character,
+        row: inout [String],
+        rows: inout [[String]],
+        field: inout String,
+        isQuoted: Bool
+    ) {
+        if !isQuoted, character == "," {
+            row.append(field)
+            field = ""
+            return
+        }
+
+        if !isQuoted, character == "\n" {
+            row.append(field)
+            rows.append(row)
+            row = []
+            field = ""
+            return
+        }
+
+        if character != "\r" {
+            field.append(character)
+        }
+    }
+}
+
+private func decodeText(_ data: Data) -> String? {
+    String(data: data, encoding: .utf8)
+    ?? String(data: data, encoding: .isoLatin1)
+}
+
+private func escapeHTML(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "&", with: "&amp;")
+        .replacingOccurrences(of: "\"", with: "&quot;")
+        .replacingOccurrences(of: "<", with: "&lt;")
+        .replacingOccurrences(of: ">", with: "&gt;")
+}
+
+private func unescapeHTML(_ value: String) -> String {
+    value
+        .replacingOccurrences(of: "&quot;", with: "\"")
+        .replacingOccurrences(of: "&#34;", with: "\"")
+        .replacingOccurrences(of: "&apos;", with: "'")
+        .replacingOccurrences(of: "&#39;", with: "'")
+        .replacingOccurrences(of: "&lt;", with: "<")
+        .replacingOccurrences(of: "&gt;", with: ">")
+        .replacingOccurrences(of: "&amp;", with: "&")
+}
+
+private func stripHTML(_ value: String) -> String {
+    guard let expression = try? NSRegularExpression(pattern: "<[^>]+>", options: []) else {
+        return value
+    }
+
+    let range = NSRange(location: 0, length: (value as NSString).length)
+    return expression.stringByReplacingMatches(in: value, range: range, withTemplate: "")
+}

--- a/browser/Reynard/Client/Stores/BookmarkStore.swift
+++ b/browser/Reynard/Client/Stores/BookmarkStore.swift
@@ -154,6 +154,12 @@ final class BookmarkStore {
             bookmarkSnapshotLocked(url: url)
         }
     }
+
+    func allBookmarks(limit: Int = 10_000) -> [BookmarkSnapshot] {
+        stateQueue.sync {
+            fetchAllBookmarksLocked(limit: limit)
+        }
+    }
     
     // MARK: - Folder Queries
     
@@ -542,7 +548,30 @@ final class BookmarkStore {
     }
     
     // MARK: - Search
-    
+
+    private func fetchAllBookmarksLocked(limit: Int) -> [BookmarkSnapshot] {
+        guard limit > 0,
+              let statement = prepareStatementLocked(
+   """
+   SELECT id, guid, date_added, parentid, parentName, title, url
+   FROM \(Constants.bookmarkTableName)
+   WHERE type = ?
+   ORDER BY date_added DESC, id DESC
+   LIMIT ?;
+   """
+              ) else {
+            return []
+        }
+
+        defer {
+            sqlite3_finalize(statement)
+        }
+
+        sqlite3_bind_int64(statement, 1, BookmarkNodeType.bookmark.rawValue)
+        sqlite3_bind_int64(statement, 2, Int64(limit))
+        return readBookmarkSnapshotsLocked(from: statement)
+    }
+
     private func searchBookmarksPrefixLocked(matching query: String, limit: Int) -> [BookmarkSnapshot] {
         let normalizedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedQuery.isEmpty, limit > 0 else {

--- a/browser/Reynard/Client/Stores/TabManagementStore.swift
+++ b/browser/Reynard/Client/Stores/TabManagementStore.swift
@@ -11,6 +11,10 @@ import UIKit
 
 final class TabManagementStore {
     static let shared = TabManagementStore()
+
+    private enum Schema {
+        static let currentVersion = 2
+    }
     
     enum LastTabOverview: String, Codable {
         case regular
@@ -44,6 +48,7 @@ final class TabManagementStore {
         let id: UUID
         let title: String
         let url: String?
+        let updatedAt: String
     }
     
     private struct PersistedState {
@@ -82,6 +87,7 @@ final class TabManagementStore {
             openDatabaseLocked()
             configureDatabaseLocked()
             createSchemaLocked()
+            migrateSchemaLocked()
             ensureStateRowLocked()
         }
     }
@@ -135,16 +141,18 @@ final class TabManagementStore {
         privateTabs: [Tab],
         selectedRegularTabID: UUID?,
         selectedPrivateTabID: UUID?,
-        selectedTabMode: TabMode
+        selectedTabMode: TabMode,
+        waitUntilFinished: Bool = false
     ) {
+        let updatedAt = Self.currentTimestamp()
         let persistedRegularTabs = regularTabs.map {
-            PersistedTab(id: $0.id, title: $0.title, url: $0.url)
+            PersistedTab(id: $0.id, title: $0.title, url: $0.url, updatedAt: updatedAt)
         }
         let persistedPrivateTabs = privateTabs.map {
-            PersistedTab(id: $0.id, title: $0.title, url: $0.url)
+            PersistedTab(id: $0.id, title: $0.title, url: $0.url, updatedAt: updatedAt)
         }
         
-        stateQueue.async {
+        let persistWork = {
             let lastTabOverview = self.persistedStateLocked().lastTabOverview
             
             guard self.executeLocked("BEGIN IMMEDIATE TRANSACTION;") else {
@@ -156,7 +164,8 @@ final class TabManagementStore {
                     selectedRegularTabID: selectedRegularTabID,
                     selectedPrivateTabID: selectedPrivateTabID,
                     selectedTabMode: selectedTabMode,
-                    lastTabOverview: lastTabOverview
+                    lastTabOverview: lastTabOverview,
+                    updatedAt: updatedAt
                   ),
                   self.insertTabsLocked(persistedRegularTabs, isPrivate: false),
                   self.insertTabsLocked(persistedPrivateTabs, isPrivate: true) else {
@@ -171,6 +180,12 @@ final class TabManagementStore {
             
             self.pruneThumbCacheLocked(validTabIDs: Set((persistedRegularTabs + persistedPrivateTabs).map(\.id)))
         }
+
+        if waitUntilFinished {
+            stateQueue.sync(execute: persistWork)
+        } else {
+            stateQueue.async(execute: persistWork)
+        }
     }
     
     func persistLastOverview(_ lastTabOverview: LastTabOverview) {
@@ -180,7 +195,8 @@ final class TabManagementStore {
                 selectedRegularTabID: state.selectedRegularTabID,
                 selectedPrivateTabID: state.selectedPrivateTabID,
                 selectedTabMode: state.selectedTabMode,
-                lastTabOverview: lastTabOverview
+                lastTabOverview: lastTabOverview,
+                updatedAt: Self.currentTimestamp()
             )
         }
     }
@@ -254,7 +270,9 @@ final class TabManagementStore {
             selected_regular_tab_id TEXT,
             selected_private_tab_id TEXT,
             selected_tab_mode TEXT NOT NULL,
-            last_tab_overview TEXT NOT NULL
+            last_tab_overview TEXT NOT NULL,
+            schema_version INTEGER NOT NULL DEFAULT 1,
+            updated_at TEXT NOT NULL DEFAULT ''
         );
         
         CREATE TABLE IF NOT EXISTS tabs (
@@ -262,13 +280,32 @@ final class TabManagementStore {
             title TEXT NOT NULL,
             url TEXT,
             is_private INTEGER NOT NULL,
-            position INTEGER NOT NULL
+            position INTEGER NOT NULL,
+            updated_at TEXT NOT NULL DEFAULT ''
         );
         
         CREATE INDEX IF NOT EXISTS idx_tabs_private_position ON tabs(is_private, position ASC);
         """
         
         _ = executeLocked(sql)
+    }
+
+    private func migrateSchemaLocked() {
+        ensureColumnLocked(
+            table: "tab_state",
+            column: "schema_version",
+            definition: "INTEGER NOT NULL DEFAULT 1"
+        )
+        ensureColumnLocked(
+            table: "tab_state",
+            column: "updated_at",
+            definition: "TEXT NOT NULL DEFAULT ''"
+        )
+        ensureColumnLocked(
+            table: "tabs",
+            column: "updated_at",
+            definition: "TEXT NOT NULL DEFAULT ''"
+        )
     }
     
     private func ensureStateRowLocked() {
@@ -277,7 +314,8 @@ final class TabManagementStore {
             selectedRegularTabID: state.selectedRegularTabID,
             selectedPrivateTabID: state.selectedPrivateTabID,
             selectedTabMode: state.selectedTabMode,
-            lastTabOverview: state.lastTabOverview
+            lastTabOverview: state.lastTabOverview,
+            updatedAt: Self.currentTimestamp()
         )
     }
     
@@ -322,17 +360,20 @@ final class TabManagementStore {
         selectedRegularTabID: UUID?,
         selectedPrivateTabID: UUID?,
         selectedTabMode: TabMode,
-        lastTabOverview: LastTabOverview
+        lastTabOverview: LastTabOverview,
+        updatedAt: String
     ) -> Bool {
         guard let statement = prepareStatementLocked(
             """
-            INSERT INTO tab_state (id, selected_regular_tab_id, selected_private_tab_id, selected_tab_mode, last_tab_overview)
-            VALUES (1, ?, ?, ?, ?)
+            INSERT INTO tab_state (id, selected_regular_tab_id, selected_private_tab_id, selected_tab_mode, last_tab_overview, schema_version, updated_at)
+            VALUES (1, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(id) DO UPDATE SET
                 selected_regular_tab_id = excluded.selected_regular_tab_id,
                 selected_private_tab_id = excluded.selected_private_tab_id,
                 selected_tab_mode = excluded.selected_tab_mode,
-                last_tab_overview = excluded.last_tab_overview;
+                last_tab_overview = excluded.last_tab_overview,
+                schema_version = excluded.schema_version,
+                updated_at = excluded.updated_at;
             """
         ) else {
             return false
@@ -346,6 +387,8 @@ final class TabManagementStore {
         bindOptional(selectedPrivateTabID?.uuidString, to: statement, at: 2)
         bind(selectedTabMode.rawValue, to: statement, at: 3)
         bind(lastTabOverview.rawValue, to: statement, at: 4)
+        sqlite3_bind_int64(statement, 5, Int64(Schema.currentVersion))
+        bind(updatedAt, to: statement, at: 6)
         return sqlite3_step(statement) == SQLITE_DONE
     }
     
@@ -424,8 +467,8 @@ final class TabManagementStore {
     private func insertTabsLocked(_ tabs: [PersistedTab], isPrivate: Bool) -> Bool {
         guard let statement = prepareStatementLocked(
             """
-            INSERT INTO tabs (id, title, url, is_private, position)
-            VALUES (?, ?, ?, ?, ?);
+            INSERT INTO tabs (id, title, url, is_private, position, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?);
             """
         ) else {
             return false
@@ -443,6 +486,7 @@ final class TabManagementStore {
             bindOptional(tab.url, to: statement, at: 3)
             sqlite3_bind_int64(statement, 4, isPrivate ? 1 : 0)
             sqlite3_bind_int64(statement, 5, Int64(index))
+            bind(tab.updatedAt, to: statement, at: 6)
             
             guard sqlite3_step(statement) == SQLITE_DONE else {
                 return false
@@ -500,6 +544,30 @@ final class TabManagementStore {
         }
         return result == SQLITE_OK
     }
+
+    private func ensureColumnLocked(table: String, column: String, definition: String) {
+        guard !columnNamesLocked(for: table).contains(column) else {
+            return
+        }
+
+        _ = executeLocked("ALTER TABLE \(table) ADD COLUMN \(column) \(definition);")
+    }
+
+    private func columnNamesLocked(for table: String) -> Set<String> {
+        guard let statement = prepareStatementLocked("PRAGMA table_info(\(table));") else {
+            return []
+        }
+
+        defer {
+            sqlite3_finalize(statement)
+        }
+
+        var names = Set<String>()
+        while sqlite3_step(statement) == SQLITE_ROW {
+            names.insert(string(from: statement, at: 1))
+        }
+        return names
+    }
     
     private func prepareStatementLocked(_ sql: String) -> OpaquePointer? {
         guard let database else {
@@ -544,5 +612,9 @@ final class TabManagementStore {
         }
         
         return string(from: statement, at: index)
+    }
+
+    private static func currentTimestamp() -> String {
+        ISO8601DateFormatter().string(from: Date())
     }
 }

--- a/browser/Reynard/Client/TabManagement/TabManager.swift
+++ b/browser/Reynard/Client/TabManagement/TabManager.swift
@@ -40,6 +40,7 @@ protocol TabManager: AnyObject {
     func updateThumbnail(_ image: UIImage?, forTabAt index: Int)
     @discardableResult
     func changeWebsiteModeForSelectedTab() -> Bool
+    func flushStateForLifecycleEvent()
 }
 
 enum TabManagerUpdateReason {

--- a/browser/Reynard/Client/TabManagement/TabManager.swift
+++ b/browser/Reynard/Client/TabManagement/TabManager.swift
@@ -41,6 +41,10 @@ protocol TabManager: AnyObject {
     @discardableResult
     func changeWebsiteModeForSelectedTab() -> Bool
     func flushStateForLifecycleEvent()
+    @discardableResult
+    func recoverSelectedTabForForeground() -> Bool
+    @discardableResult
+    func rebuildSelectedTabSessionForForeground() -> Bool
 }
 
 enum TabManagerUpdateReason {

--- a/browser/Reynard/Client/TabManagement/TabManagerImpl.swift
+++ b/browser/Reynard/Client/TabManagement/TabManagerImpl.swift
@@ -750,6 +750,10 @@ final class TabManagerImplementation: NSObject, TabManager {
         tab.thumbnail = image
         store.persistThumbnail(image, for: tab.id)
     }
+
+    func flushStateForLifecycleEvent() {
+        persistState()
+    }
     
     // MARK: - Session Factory
     

--- a/browser/Reynard/Client/TabManagement/TabManagerImpl.swift
+++ b/browser/Reynard/Client/TabManagement/TabManagerImpl.swift
@@ -10,6 +10,13 @@ import GeckoView
 import UIKit
 
 final class TabManagerImplementation: NSObject, TabManager {
+    private enum SessionReplacementReason {
+        case foregroundClosedSession
+        case foregroundDetachedContent
+        case crash
+        case kill
+    }
+
     private(set) var regularTabs: [Tab] = []
     private(set) var privateTabs: [Tab] = []
     private(set) var selectedTabMode: TabMode = .regular
@@ -67,13 +74,14 @@ final class TabManagerImplementation: NSObject, TabManager {
         faviconTasks.removeValue(forKey: tabID)?.cancel()
     }
     
-    private func persistState() {
+    private func persistState(waitUntilFinished: Bool = false) {
         store.persistTabs(
             regularTabs: regularTabs,
             privateTabs: privateTabs,
             selectedRegularTabID: regularTabs[safe: selectedRegularTabIndex]?.id,
             selectedPrivateTabID: privateTabs[safe: selectedPrivateTabIndex]?.id,
-            selectedTabMode: selectedTabMode
+            selectedTabMode: selectedTabMode,
+            waitUntilFinished: waitUntilFinished
         )
     }
     
@@ -752,7 +760,116 @@ final class TabManagerImplementation: NSObject, TabManager {
     }
 
     func flushStateForLifecycleEvent() {
+        persistState(waitUntilFinished: true)
+    }
+
+    @discardableResult
+    func recoverSelectedTabForForeground() -> Bool {
+        if selectedTab == nil {
+            selectFallbackTabIfNeeded()
+        }
+
+        if selectedTab == nil {
+            createInitialTab()
+            selectFallbackTabIfNeeded()
+        }
+
+        guard let selectedTab else {
+            return false
+        }
+
+        guard selectedTab.session.isOpen() else {
+            return replaceSession(
+                forTabWithID: selectedTab.id,
+                reason: .foregroundClosedSession
+            )
+        }
+
+        if let url = restoredURL(from: selectedTab.url) {
+            sessionManager.updateSettings(of: selectedTab.session, for: url, tabID: selectedTab.id)
+        }
+        sessionManager.activate(selectedTab.session)
+        return false
+    }
+
+    private func selectFallbackTabIfNeeded() {
+        if !tabs(for: selectedTabMode).isEmpty {
+            let index = min(max(selectedIndex(for: selectedTabMode), 0), tabs(for: selectedTabMode).count - 1)
+            selectTab(at: index, mode: selectedTabMode)
+            return
+        }
+
+        if !regularTabs.isEmpty {
+            selectTab(at: min(max(selectedRegularTabIndex, 0), regularTabs.count - 1), mode: .regular)
+            return
+        }
+
+        if !privateTabs.isEmpty {
+            selectTab(at: min(max(selectedPrivateTabIndex, 0), privateTabs.count - 1), mode: .private)
+        }
+    }
+
+    @discardableResult
+    func rebuildSelectedTabSessionForForeground() -> Bool {
+        guard let selectedTab else {
+            return false
+        }
+
+        return replaceSession(
+            forTabWithID: selectedTab.id,
+            reason: .foregroundDetachedContent
+        )
+    }
+
+    @discardableResult
+    private func replaceSession(
+        forTabWithID tabID: UUID,
+        reason _: SessionReplacementReason
+    ) -> Bool {
+        guard let location = tabLocation(for: tabID) else {
+            return false
+        }
+
+        let tab = tabs(for: location.mode)[location.index]
+        let previousSession = tab.session
+        let replacementSession = createSession(
+            tabID: tab.id,
+            url: tab.url,
+            windowId: nil,
+            isPrivate: tab.isPrivate
+        )
+        tab.session = replacementSession
+        tab.state.restoreState = .none
+        tab.state.sessionNavigationAvailability = .unavailable
+        tab.state.navigationState = sessionManager.useStoredNavigationHistory(for: tab.id)
+        tab.state.isSuppressingInitialBlankPageLoad = false
+
+        if let url = restoredURL(from: tab.url) {
+            tab.state.suppressInitialNavigation = false
+            tab.state.displayState = .pending(url)
+            loadURL(url, in: tab)
+        } else {
+            tab.state.suppressInitialNavigation = true
+            tab.state.displayState = .committed
+            tab.state.loadingState = .idle
+        }
+
+        if selectedTab?.id == tab.id {
+            sessionManager.activate(replacementSession)
+        } else {
+            sessionManager.deactivate(replacementSession)
+        }
+
+        delegate?.tabManagerDidChangeTabs(self)
+        if selectedTab?.id == tab.id {
+            delegate?.tabManager(self, didReplaceSelectedSession: previousSession, with: replacementSession)
+            notifyUpdate(at: location.index, mode: location.mode, reason: .navigationState)
+            notifyUpdate(at: location.index, mode: location.mode, reason: .loading)
+        }
+        scheduleFaviconUpdate(forTabAt: location.index, mode: location.mode)
         persistState()
+        sessionManager.close(previousSession)
+        return true
     }
     
     // MARK: - Session Factory
@@ -836,14 +953,16 @@ extension TabManagerImplementation: ContentDelegate {
         guard let location = tabLocation(for: session) else {
             return
         }
-        removeTab(at: location.index, mode: location.mode)
+        let tabID = tabs(for: location.mode)[location.index].id
+        replaceSession(forTabWithID: tabID, reason: .crash)
     }
     
     func onKill(session: GeckoSession) {
         guard let location = tabLocation(for: session) else {
             return
         }
-        removeTab(at: location.index, mode: location.mode)
+        let tabID = tabs(for: location.mode)[location.index].id
+        replaceSession(forTabWithID: tabID, reason: .kill)
     }
     
     func onFirstComposite(session: GeckoSession) {}

--- a/browser/Reynard/SceneDelegate.swift
+++ b/browser/Reynard/SceneDelegate.swift
@@ -16,6 +16,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         let browserViewController = BrowserViewController()
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = browserViewController
+        BrowserAppearance.apply(to: window)
         window.makeKeyAndVisible()
         self.window = window
         
@@ -28,13 +29,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     func sceneDidDisconnect(_ scene: UIScene) {}
     
-    func sceneDidBecomeActive(_ scene: UIScene) {}
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        BrowserAppearance.apply(to: window)
+        browserViewController?.restoreBrowserStateAfterForeground()
+    }
     
-    func sceneWillResignActive(_ scene: UIScene) {}
+    func sceneWillResignActive(_ scene: UIScene) {
+        browserViewController?.saveBrowserStateForLifecycleEvent("sceneWillResignActive")
+    }
     
-    func sceneWillEnterForeground(_ scene: UIScene) {}
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        BrowserAppearance.apply(to: window)
+    }
     
-    func sceneDidEnterBackground(_ scene: UIScene) {}
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        browserViewController?.saveBrowserStateForLifecycleEvent("sceneDidEnterBackground")
+    }
+
+    private var browserViewController: BrowserViewController? {
+        window?.rootViewController as? BrowserViewController
+    }
     
     private func handleIncomingURLContexts(_ urlContexts: Set<UIOpenURLContext>) {
         guard let incomingURL = urlContexts.first?.url else {

--- a/browser/Reynard/SceneDelegate.swift
+++ b/browser/Reynard/SceneDelegate.swift
@@ -27,7 +27,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         handleIncomingURLContexts(URLContexts)
     }
     
-    func sceneDidDisconnect(_ scene: UIScene) {}
+    func sceneDidDisconnect(_ scene: UIScene) {
+        browserViewController?.saveBrowserStateForLifecycleEvent("sceneDidDisconnect")
+    }
     
     func sceneDidBecomeActive(_ scene: UIScene) {
         BrowserAppearance.apply(to: window)

--- a/browser/Scripts/AddGecko.sh
+++ b/browser/Scripts/AddGecko.sh
@@ -8,8 +8,14 @@ FRAMEWORKS_DIR="${APP_BUNDLE}/Frameworks"
 GECKOVIEW_FW="${FRAMEWORKS_DIR}/GeckoView.framework"
 GECKOVIEW_FW_FRAMEWORKS="${GECKOVIEW_FW}/Frameworks"
 
-SIGN_IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:-${EXPANDED_CODE_SIGN_IDENTITY_NAME:-Apple Development}}"
 DEFAULT_THEME_SRC="${SRCROOT}/../engine/firefox/toolkit/mozapps/extensions/default-theme"
+
+SIGN_IDENTITY="${EXPANDED_CODE_SIGN_IDENTITY:-${EXPANDED_CODE_SIGN_IDENTITY_NAME:-}}"
+SHOULD_CODE_SIGN=1
+if [ "${CODE_SIGNING_ALLOWED:-YES}" = "NO" ] || [ -z "${SIGN_IDENTITY}" ]; then
+	SHOULD_CODE_SIGN=0
+	echo "Skipping Gecko code signing in Copy Gecko Stuff"
+fi
 
 mkdir -p "${FRAMEWORKS_DIR}"
 mkdir -p "${GECKOVIEW_FW_FRAMEWORKS}"
@@ -20,7 +26,9 @@ cp -fL "${GECKO_DIST_BIN}/XUL" "${GECKOVIEW_FW}/XUL"
 
 for file in "${GECKOVIEW_FW}/XUL" "${FRAMEWORKS_DIR}/"*.dylib; do
 	if [ -f "${file}" ]; then
-		codesign --force --sign "${SIGN_IDENTITY}" --preserve-metadata=identifier,entitlements "${file}"
+		if [ "${SHOULD_CODE_SIGN}" = "1" ]; then
+			codesign --force --sign "${SIGN_IDENTITY}" --preserve-metadata=identifier,entitlements "${file}"
+		fi
 	fi
 done
 
@@ -33,4 +41,6 @@ cp -RfL "${DEFAULT_THEME_SRC}/" "${GECKOVIEW_FW_FRAMEWORKS}/default-theme/"
 echo "resource default-theme file:default-theme/" >> "${GECKOVIEW_FW_FRAMEWORKS}/chrome.manifest"
 
 # sign the GeckoView.framework
-codesign --force --sign "${SIGN_IDENTITY}" "${GECKOVIEW_FW}"
+if [ "${SHOULD_CODE_SIGN}" = "1" ]; then
+	codesign --force --sign "${SIGN_IDENTITY}" "${GECKOVIEW_FW}"
+fi

--- a/patches/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs.patch
+++ b/patches/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs.patch
@@ -1,0 +1,33 @@
+diff --git a/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs b/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs
+--- a/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs
++++ b/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs
+@@ -84,6 +84,7 @@ export class GeckoViewSettings extends GeckoViewModule {
+     this.allowJavascript = settings.allowJavascript;
+     this.viewportMode = settings.viewportMode;
+     this.useTrackingProtection = !!settings.useTrackingProtection;
+-
++    this.pageZoom = settings.pageZoom ?? 1.0;
++
+     if (settings.isExtensionPopup) {
+       // NOTE: Only add the webextension-view-type and emit extension-browser-inserted
+@@ -134,6 +135,19 @@ export class GeckoViewSettings extends GeckoViewModule {
+       aViewportMode == VIEWPORT_MODE_DESKTOP;
+   }
+-
++
++  set pageZoom(aPageZoom) {
++    const zoom = Number(aPageZoom ?? 1.0);
++    if (!Number.isFinite(zoom) || zoom <= 0) {
++      return;
++    }
++
++    if (this.browsingContext.fullZoom.toFixed(2) === zoom.toFixed(2)) {
++      return;
++    }
++
++    this.browsingContext.fullZoom = zoom;
++  }
++
+   get userAgentMode() {
+     return this._userAgentMode;
+   }

--- a/tools/development/build-gecko.sh
+++ b/tools/development/build-gecko.sh
@@ -7,6 +7,7 @@ ROOT_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/../.." && pwd)"
 FIREFOX_DIR="$ROOT_DIR/engine/firefox"
 
 TARGET="aarch64-apple-ios"
+MOZ_BUILD_JOBS="${MOZ_BUILD_JOBS:-12}"
 
 cd "$ROOT_DIR"
 
@@ -21,6 +22,15 @@ rm -f "$FIREFOX_DIR/.mozconfig"
 {
 	echo "ac_add_options --enable-application=mobile/ios"
 	echo "ac_add_options --target=$TARGET"
+	if [ -n "${MOZ_LINKER:-}" ]; then
+		echo "ac_add_options --enable-linker=$MOZ_LINKER"
+	fi
+	if [ -n "${WASI_SYSROOT:-}" ]; then
+		echo "ac_add_options --with-wasi-sysroot=$WASI_SYSROOT"
+	fi
+	if [ -n "${SCCACHE_BIN:-}" ] && [ -x "$SCCACHE_BIN" ]; then
+		echo "ac_add_options CCACHE=$SCCACHE_BIN"
+	fi
 	echo "ac_add_options --enable-ios-target=13.0"
 	echo "ac_add_options --enable-webrtc"
 	echo "ac_add_options --enable-optimize"
@@ -33,4 +43,12 @@ if ! rustup target list | grep -q "^$TARGET (installed)"; then
 fi
 
 cd "$FIREFOX_DIR"
-./mach build
+if [ -n "${SCCACHE_BIN:-}" ] && [ -x "$SCCACHE_BIN" ]; then
+	"$SCCACHE_BIN" -s || true
+fi
+
+./mach build -j "$MOZ_BUILD_JOBS"
+
+if [ -n "${SCCACHE_BIN:-}" ] && [ -x "$SCCACHE_BIN" ]; then
+	"$SCCACHE_BIN" -s || true
+fi

--- a/tools/development/build-gecko.sh
+++ b/tools/development/build-gecko.sh
@@ -8,6 +8,8 @@ FIREFOX_DIR="$ROOT_DIR/engine/firefox"
 
 TARGET="aarch64-apple-ios"
 MOZ_BUILD_JOBS="${MOZ_BUILD_JOBS:-12}"
+CONFIGURED_MOZ_LINKER="${MOZ_LINKER:-}"
+CONFIGURED_WASI_SYSROOT="${WASI_SYSROOT:-}"
 
 cd "$ROOT_DIR"
 
@@ -22,11 +24,11 @@ rm -f "$FIREFOX_DIR/.mozconfig"
 {
 	echo "ac_add_options --enable-application=mobile/ios"
 	echo "ac_add_options --target=$TARGET"
-	if [ -n "${MOZ_LINKER:-}" ]; then
-		echo "ac_add_options --enable-linker=$MOZ_LINKER"
+	if [ -n "$CONFIGURED_MOZ_LINKER" ]; then
+		echo "ac_add_options --enable-linker=$CONFIGURED_MOZ_LINKER"
 	fi
-	if [ -n "${WASI_SYSROOT:-}" ]; then
-		echo "ac_add_options --with-wasi-sysroot=$WASI_SYSROOT"
+	if [ -n "$CONFIGURED_WASI_SYSROOT" ]; then
+		echo "ac_add_options --with-wasi-sysroot=$CONFIGURED_WASI_SYSROOT"
 	fi
 	if [ -n "${SCCACHE_BIN:-}" ] && [ -x "$SCCACHE_BIN" ]; then
 		echo "ac_add_options CCACHE=$SCCACHE_BIN"
@@ -43,6 +45,8 @@ if ! rustup target list | grep -q "^$TARGET (installed)"; then
 fi
 
 cd "$FIREFOX_DIR"
+unset MOZ_LINKER
+
 if [ -n "${SCCACHE_BIN:-}" ] && [ -x "$SCCACHE_BIN" ]; then
 	"$SCCACHE_BIN" -s || true
 fi

--- a/tools/release/build-app.sh
+++ b/tools/release/build-app.sh
@@ -16,4 +16,11 @@ cp "$XCCONFIG_PATH" "$DIST_DIR/Reynard.xcconfig"
 BUILD_SHA=$(git -C "$ROOT_DIR" rev-parse --short HEAD)
 sed -i '' "s/CURRENT_BUILD = .*/CURRENT_BUILD = $BUILD_SHA/" "$DIST_DIR/Reynard.xcconfig"
 
-xcodebuild archive -scheme "Reynard" -archivePath "$DIST_DIR/Reynard.xcarchive" -project "$PROJECT_PATH" -sdk iphoneos -arch arm64 -configuration Release -xcconfig "$DIST_DIR/Reynard.xcconfig"
+SIGNING_FLAGS=
+if [ "${REYNARD_UNSIGNED_ARCHIVE:-0}" = "1" ]; then
+	SIGNING_FLAGS='CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= DEVELOPMENT_TEAM= PROVISIONING_PROFILE_SPECIFIER='
+fi
+
+# SIGNING_FLAGS is intentionally split into xcodebuild KEY=VALUE arguments.
+# shellcheck disable=SC2086
+xcodebuild archive -scheme "Reynard" -archivePath "$DIST_DIR/Reynard.xcarchive" -project "$PROJECT_PATH" -sdk iphoneos -arch arm64 -configuration Release -xcconfig "$DIST_DIR/Reynard.xcconfig" $SIGNING_FLAGS


### PR DESCRIPTION
## Summary
- Adds a latest-main IPA build workflow with Gecko `sccache` restore/save, reusable Gecko dist checkpointing, and an archive-only IPA workflow for fast native/archive iteration.
- Adds Page Zoom with Gecko-backed page zoom settings, per-site/default persistence, a persistent slider sheet, plus/minus controls, reset, and live active-tab application.
- Adds native UX improvements for lifecycle state flush/foreground restore, address-bar local autocomplete, opt-in debounced search suggestions, bookmark/history import/export, OLED Black, and accent customization.
- Fixes the page-keyboard obstruction path by resizing/insetting the native Gecko content viewport above the actual keyboard/content overlap before applying focused-input correction.
- Adds full custom accent color support in Appearance settings with preset accents, a Custom swatch row, native color picker on iOS 14+, hex entry, persistence, immediate application, and low-contrast/invalid color rejection.
- Publishes the custom accent prerelease IPA: https://github.com/lowestprime/reynard-browser/releases/tag/reynard-custom-accent-color-2026-06-24

## Why
The IPA pipeline previously made every archive-stage problem expensive because it required a long Gecko rebuild. This branch keeps the cached/checkpointed build path, adds the requested Page Zoom feature, repairs the real-device keyboard obstruction regression reported on ChatGPT and Gemini bottom composers, and expands the limited accent presets into a full custom color workflow.

## Files / areas touched
- `.github/workflows/build-latest-reynard-ipa.yml`
- `.github/workflows/archive-reynard-ipa-from-gecko-dist.yml`
- `tools/development/build-gecko.sh`
- `tools/release/build-app.sh`
- `browser/Scripts/AddGecko.sh`
- `browser/Reynard/Client/Interface/Appearance/BrowserAppearance.swift`
- `browser/Reynard/Client/Interface/BrowserViewController.swift`
- `browser/Reynard/Client/Interface/ContentView/ContentView.swift`
- `browser/Reynard/Client/Interface/Library/Settings/Sections/General/Appearance/AppearancePreferencesViewController.swift`
- `browser/Reynard/Client/Interface/**`
- `browser/Reynard/Client/Preferences/BrowserPreferences.swift`
- `browser/Reynard/Client/Search/**`
- `browser/Reynard/Client/Storage/BrowsingDataTransfer.swift`
- `browser/Reynard/Client/Stores/BookmarkStore.swift`
- `browser/Reynard/Client/SessionManagement/Settings/**`
- `browser/GeckoView/Session/GeckoSession.swift`
- `patches/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs.patch`
- `.agent/execplans/20260623_reynard-latest-ipa-page-zoom.md`

## Validation
- `git diff --check` passed.
- `bash -n tools/development/build-gecko.sh` passed.
- `bash -n tools/release/build-app.sh` passed.
- `bash -n browser/Scripts/AddGecko.sh` passed.
- `git -C engine/firefox apply --check ../../patches/mobile/shared/modules/geckoview/GeckoViewSettings.sys.mjs.patch` passed earlier for the Gecko patch in this branch.
- `Build Latest Reynard IPA` run `28038685786` passed for the Page Zoom build: https://github.com/lowestprime/reynard-browser/actions/runs/28038685786
- `Archive Reynard IPA From Gecko Dist` run `28077200523` passed for the keyboard avoidance fix without rebuilding Gecko: https://github.com/lowestprime/reynard-browser/actions/runs/28077200523
- `Archive Reynard IPA From Gecko Dist` run `28080748345` passed for the custom accent build in 7m37s without rebuilding Gecko: https://github.com/lowestprime/reynard-browser/actions/runs/28080748345
- Downloaded `C:\Users\Cooper\Downloads\Reynard-latest-main-28080748345\Reynard.ipa`; `unzip -tq` reported no compressed-data errors.
- Local IPA inspection found 3,032 ZIP entries, no duplicate paths, the main app, `Reynard Helper.appex`, `OpenIn.appex`, `GeckoView.framework/GeckoView`, arm64 Mach-O headers, and matching `CFBundleVersion` `e3c2624` for the app and extensions.
- Marker scan found `Custom`, `Custom Accent`, `Custom Accent Hex`, `Choose Custom Color`, `#RRGGBB`, `Invalid Accent Color`, all preset accent names, `customAccent`, `AppearanceSettings`, `OLED Black`, and `Page Zoom`.
- Local SHA-256 for the custom-accent `Reynard.ipa`: `c53caab3fe6d857b7c9a0328d70290b0df2e35f707ec869505853cbe82dcae46`.

## Caveats / follow-up
- Current PR head `2aaa124` records the release in the ExecPlan; the validated custom-accent app-code IPA targets commit `e3c2624e4b9628e2f042aebd8adeb22012779a31`.
- The release IPA is intentionally unsigned for sideload packaging.
- History/bookmark transfer is local import/export; this does not implement or claim Firefox Sync.
- Physical iPhone validation is still required for the custom accent UI: presets plus Custom row, color picker, hex validation, preview updates, persistence after app relaunch, all theme modes, and existing Page Zoom/keyboard behavior.
- Physical iOS 26.6 / iPhone 15 Pro Max JIT/TXM, SideStore, and LocalDevVPN behavior still needs device validation.
- Local Xcode and Swift checks were not run on this Windows host; the iPhoneOS archive and IPA packaging were validated by GitHub Actions.
