### PR TITLE
Fix launch crash on libhooker-based jailbreaks (REYNARD_DISABLE_JEMALLOC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ Build dependencies and the Gecko engine.
 
 To run Reynard, open `Reynard.xcodeproj` in Xcode and build/run it from there.
 
+### Building for jailbroken devices
+
+On libhooker-based jailbreaks (e.g. Taurine), the stock build crashes at launch: jemalloc registers its own malloc zone during dyld initialization (`memory/build/zone.c`), which conflicts with the jailbreak's hook installer (`pspawn_payload-stg2.dylib`) and aborts the process in `free()` before `main()` runs.
+
+To keep the system allocator, build Gecko with jemalloc disabled:
+
+```bash
+REYNARD_DISABLE_JEMALLOC=1 ./tools/development/build-gecko.sh
+```
+
+Then package and install the `Reynard-Jailbroken.ipa` build as usual.
+
 ## Notes
 
 This project initially started out of curiosity. I wanted to see if I could get Gecko to run without the [BrowserEngineKit](https://developer.apple.com/documentation/browserenginekit) framework, so it could be further modified to run on iOS versions as far back as possible. I got it working, and since then, I’ve been focusing on developing engine patches for better UIKit integration, fixing bugs, and turning this into a full, usable browser.

--- a/tools/development/build-gecko.sh
+++ b/tools/development/build-gecko.sh
@@ -28,6 +28,14 @@ mv "$FIREFOX_DIR/.mozconfig" "$FIREFOX_DIR/.mozconfig.bak"
 	echo "ac_add_options --enable-rust-simd"
 	echo "ac_add_options --enable-lto"
 	echo "ac_add_options --disable-debug"
+	# On libhooker-based jailbreaks (e.g. Taurine), jemalloc's malloc zone
+	# registration (memory/build/zone.c) conflicts with the jailbreak's hook
+	# installer: pspawn_payload-stg2.dylib aborts in free() during dyld
+	# initialization, before main() runs. REYNARD_DISABLE_JEMALLOC=1 keeps
+	# the system allocator so the app can launch on those devices.
+	if [ "${REYNARD_DISABLE_JEMALLOC:-0}" = "1" ]; then
+		echo "ac_add_options --disable-jemalloc"
+	fi
 	echo "ac_add_options --disable-tests"
 } > "$FIREFOX_DIR/.mozconfig"
 


### PR DESCRIPTION
## Summary

On libhooker-based jailbreaks (e.g. Taurine on iOS 14), Reynard crashes at launch with SIGABRT before `main()` runs. This adds an opt-in `REYNARD_DISABLE_JEMALLOC=1` flag to `build-gecko.sh` that keeps the system allocator, and documents it in the README. Default builds are unchanged.

## Root cause

Symbolicated crash log from an iPhone 8 Plus (iOS 14.7.1, Taurine 1.1.7):

- SIGABRT from `libsystem_malloc` → `free` → `malloc_report` → `abort`
- Called from `pspawn_payload-stg2.dylib` → `LHHookFunctions` (libhooker's hook installer)
- Under `dyld::initializeMainExecutable` / `doModInitFunctions` - no app code on the stack

Gecko's `libmozglue.dylib` registers jemalloc as a malloc zone during dyld initialization (`memory/build/zone.c`), replacing the default Darwin zone. libhooker allocates/frees scratch memory while installing hooks; the zone bookkeeping is inconsistent (a pointer allocated through one zone table is freed through another), so `libsystem_malloc` aborts on the "pointer being freed was not allocated" assertion.

## Fix

`REYNARD_DISABLE_JEMALLOC=1 ./tools/development/build-gecko.sh` adds `ac_add_options --disable-jemalloc` to the generated mozconfig. With the system allocator kept, the jailbreak's hook installer no longer trips the zone check.

An alternative considered was patching out only the zone registration in `memory/build/zone.c`, but jemalloc remains deeply intertwined with mozglue on Apple platforms, and disabling it entirely is the approach Mozilla's own configure supports cleanly.

## Test plan

- [x] Built 0.8.0 with `REYNARD_DISABLE_JEMALLOC=1` equivalent (verified `libmozglue.dylib` no longer references `malloc_zone_register`)
- [x] Installed on iPhone 8 Plus, iOS 14.7.1, Taurine 1.1.7 with libhooker injection active
- [x] App launches and runs; no new crash reports on device
- [ ] Maintainer CI/release flow unaffected (flag is opt-in; default build unchanged)
