### PR TITLE
Add hard reload using cmd + shift + R or long press on the reload button

### DIFF
--- a/browser/GeckoView/Session/GeckoSession.swift
+++ b/browser/GeckoView/Session/GeckoSession.swift
@@ -15,6 +15,7 @@ protocol GeckoSessionHandlerCommon: GeckoEventListenerInternal {
 
 public enum GeckoSessionLoadFlags {
     public static let none = 0
+    public static let bypassCache = 1 << 0
     public static let replaceHistory = 1 << 6
 }
 
@@ -274,11 +275,11 @@ public class GeckoSession {
             ])
     }
     
-    public func reload() {
+    public func reload(flags: Int = GeckoSessionLoadFlags.none) {
         dispatcher.dispatch(
             type: "GeckoView:Reload",
             message: [
-                "flags": 0
+                "flags": flags
             ])
     }
     

--- a/browser/Reynard/ApplicationMenuBuilder.swift
+++ b/browser/Reynard/ApplicationMenuBuilder.swift
@@ -36,6 +36,7 @@ enum ApplicationMenuBuilder {
         
         let viewMenu = UIMenu(title: "", options: .displayInline, children: [
             UIKeyCommand(title: NSLocalizedString("Reload Page", comment: ""), action: #selector(BrowserViewController.reloadPageKeyCommand(_:)), input: "r", modifierFlags: .command),
+            UIKeyCommand(title: NSLocalizedString("Hard Reload Page", comment: ""), action: #selector(BrowserViewController.hardReloadPageKeyCommand(_:)), input: "r", modifierFlags: [.command, .shift]),
             UIKeyCommand(title: NSLocalizedString("Zoom In", comment: ""), action: #selector(BrowserViewController.zoomInKeyCommand(_:)), input: "+", modifierFlags: .command),
             UIKeyCommand(title: NSLocalizedString("Zoom Out", comment: ""), action: #selector(BrowserViewController.zoomOutKeyCommand(_:)), input: "-", modifierFlags: .command),
             UIKeyCommand(title: NSLocalizedString("Actual Size", comment: ""), action: #selector(BrowserViewController.actualSizeKeyCommand(_:)), input: "0", modifierFlags: .command),

--- a/browser/Reynard/Client/Interface/BrowserViewController+AddressBar.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController+AddressBar.swift
@@ -54,6 +54,15 @@ extension BrowserViewController: AddressBarDelegate, AddressBarGestureDelegate {
         tabManager.reloadOrStopSelectedTab()
     }
     
+    func addressBarDidRequestHardReload(_ addressBar: AddressBar) {
+        if tabManager.selectedTab?.session.isOpen() == false {
+            reloadTerminatedTab()
+            return
+        }
+        
+        tabManager.hardReloadSelectedTab()
+    }
+    
     func addressBarAddonItems(_ addressBar: AddressBar) -> [AddressBarMenu.AddonItem] {
         addonCoordinator.currentSiteMenuItems().map { item in
             AddressBarMenu.AddonItem(

--- a/browser/Reynard/Client/Interface/BrowserViewController+KeyCommands.swift
+++ b/browser/Reynard/Client/Interface/BrowserViewController+KeyCommands.swift
@@ -50,6 +50,18 @@ extension BrowserViewController {
         }
     }
     
+    @objc func hardReloadPageKeyCommand(_ sender: UIKeyCommand) {
+        guard hasSelectedWebPage,
+              let session = tabManager.selectedTab?.session else {
+            return
+        }
+        if session.isOpen() {
+            session.reload(flags: GeckoSessionLoadFlags.bypassCache)
+        } else {
+            reloadTerminatedTab()
+        }
+    }
+    
     @objc func zoomInKeyCommand(_ sender: UIKeyCommand) {
         guard hasSelectedWebPage else {
             return

--- a/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBar.swift
+++ b/browser/Reynard/Client/Interface/Chrome/AddressBar/AddressBar.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol AddressBarDelegate: AnyObject {
     func addressBarDidRequestReloadOrStop(_ addressBar: AddressBar)
+    func addressBarDidRequestHardReload(_ addressBar: AddressBar)
     func addressBarAddonItems(_ addressBar: AddressBar) -> [AddressBarMenu.AddonItem]
     func addressBar(_ addressBar: AddressBar, didSelectAddon item: AddonMenuItem)
     func addressBarDidRequestFindInPage(_ addressBar: AddressBar)
@@ -100,6 +101,7 @@ final class AddressBar: UIView {
     private var chromeMode: BrowserChromeMode = .phone
     private var autocompleteState: AutocompleteState = .none
     private var autocompleteDeletedText: String?
+    private var trailingButtonState: TrailingButtonState = .hidden
     
     private var currentText: String?
     private var currentLocationText: String?
@@ -633,6 +635,7 @@ final class AddressBar: UIView {
         addressBarContent.addInteraction(UIContextMenuInteraction(delegate: self))
         textField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         trailingButton.addTarget(self, action: #selector(handleTrailingButtonTap), for: .touchUpInside)
+        trailingButton.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(handleTrailingButtonLongPress)))
         autocompleteButton.addTarget(self, action: #selector(handleOverlayButtonTap), for: .touchUpInside)
         dismissButton.addTarget(self, action: #selector(handleDismissButtonTap), for: .touchUpInside)
     }
@@ -779,6 +782,7 @@ final class AddressBar: UIView {
     }
     
     private func applyTrailingButtonState(_ state: TrailingButtonState) {
+        trailingButtonState = state
         let visible = state != .hidden
         trailingButton.isHidden = !visible
         trailingButton.isUserInteractionEnabled = visible
@@ -874,6 +878,15 @@ final class AddressBar: UIView {
     @objc
     private func handleTrailingButtonTap() {
         delegate?.addressBarDidRequestReloadOrStop(self)
+    }
+    
+    @objc
+    private func handleTrailingButtonLongPress(_ recognizer: UILongPressGestureRecognizer) {
+        guard recognizer.state == .began, trailingButtonState == .reload else {
+            return
+        }
+        
+        delegate?.addressBarDidRequestHardReload(self)
     }
     
     @objc

--- a/browser/Reynard/Client/TabManagement/TabActions.swift
+++ b/browser/Reynard/Client/TabManagement/TabActions.swift
@@ -66,6 +66,14 @@ extension TabManager {
         selectedTab.state.loadingState.isLoading ? selectedTab.session.stop() : selectedTab.session.reload()
     }
     
+    func hardReloadSelectedTab() {
+        guard let selectedTab else {
+            return
+        }
+        
+        selectedTab.session.reload(flags: GeckoSessionLoadFlags.bypassCache)
+    }
+    
     var activeTabs: [Tab] {
         return selectedTabMode == .private ? privateTabs : regularTabs
     }


### PR DESCRIPTION
Reynard has no way to reload a page while bypassing the cache. `GeckoSession.reload()` always dispatches `GeckoView:Reload` with `flags: 0`, so every reload entry point performs a normal reload.

This adds a hard reload alongside the existing one:

- `cmd + shift + R`, shown as "Hard Reload Page" in the View menu next to "Reload Page"
- long press on the reload button in the address bar

Both send `LOAD_FLAGS_BYPASS_CACHE`, the same flag Firefox for Android uses for its bypass-cache reload. `GeckoViewNavigation.sys.mjs` maps that bit (`1 << 0`) onto the matching `nsIWebNavigation` flag.

Notes on the implementation:

- `GeckoSession.reload()` takes a `flags` parameter defaulting to `GeckoSessionLoadFlags.none`, so the existing callers are untouched.
- `GeckoSessionLoadFlags` gains `bypassCache`, following the numbering already used by `replaceHistory`.
- The long-press gesture is only available while the trailing button is offering a reload, since it becomes a stop button while loading a page.