### PR TITLE
Restore tabs lazily on startup

### DIFF
--- a/browser/Reynard/Client/TabManagement/TabManagerImpl.swift
+++ b/browser/Reynard/Client/TabManagement/TabManagerImpl.swift
@@ -368,7 +368,8 @@ final class TabManagerImplementation: NSObject, TabManager {
                     tabID: snapshot.id,
                     url: snapshot.url,
                     windowId: nil,
-                    isPrivate: false
+                    isPrivate: false,
+                    opening: .manual
                 ),
                 title: snapshot.title,
                 url: snapshot.url,
@@ -389,7 +390,8 @@ final class TabManagerImplementation: NSObject, TabManager {
                     tabID: snapshot.id,
                     url: snapshot.url,
                     windowId: nil,
-                    isPrivate: true
+                    isPrivate: true,
+                    opening: .manual
                 ),
                 title: snapshot.title,
                 url: snapshot.url,
@@ -1002,13 +1004,14 @@ final class TabManagerImplementation: NSObject, TabManager {
         tabID: UUID,
         url: String?,
         windowId: String?,
-        isPrivate: Bool
+        isPrivate: Bool,
+        opening: SessionOpening? = nil
     ) -> GeckoSession {
         return sessionManager.createSession(
             url: url,
             tabID: tabID,
             isPrivate: isPrivate,
-            opening: .immediate(windowID: windowId),
+            opening: opening ?? .immediate(windowID: windowId),
             delegates: sessionDelegates
         )
     }


### PR DESCRIPTION
# Restore tabs lazily on startup

## Summary

* Restore persisted regular and private tabs with `SessionOpening.manual`.
* Open only the selected restored tab during startup.
* Keep background restored tabs unopened until they are selected.
* Leave normal, new, recently closed, and transferred tab session creation unchanged.

## Why

`restoreTabsIfNeeded()` currently creates a `GeckoSession` for every persisted tab through a helper that always uses `.immediate`. On iOS, that means every restored tab is opened during startup, causing startup work and process launches to scale with the number of saved tabs.

The restoration path already tracks pending URLs and loads them when a tab is selected, so restored background tabs do not need an open session up front. This change uses the existing manual session-opening mode for those restored sessions instead.

## Testing

Tested on-device with a multi-tab restored session using startup tracing.

With lazy restoration enabled, startup opens only the selected restored session instead of opening every saved tab. Selecting a previously unopened restored tab still opens its session and loads its pending restored URL normally.

This PR intentionally contains only the lazy tab-restoration change; other startup-process experiments are kept separate.
