### PR TITLE
Avoid extension completion queue starvation

### DIFF
--- a/patches/ipc/glue/NSExtensionUtils.mm.patch
+++ b/patches/ipc/glue/NSExtensionUtils.mm.patch
@@ -3,7 +3,7 @@ new file mode 100644
 index 000000000000..bd49425f027c
 --- /dev/null
 +++ b/ipc/glue/NSExtensionUtils.mm
-@@ -0,0 +1,346 @@
+@@ -0,0 +1,356 @@
 +/* This Source Code Form is subject to the terms of the Mozilla Public
 + * License, v. 2.0. If a copy of the MPL was not distributed with this
 + * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
@@ -78,6 +78,16 @@ index 000000000000..bd49425f027c
 +  return queue;
 +}
 +
++static dispatch_queue_t ExtensionCompletionQueue() {
++  static dispatch_queue_t queue;
++  static dispatch_once_t onceToken;
++  dispatch_once(&onceToken, ^{
++    queue = dispatch_queue_create(
++        "com.minh-ton.Reynard.ExtensionCompletionQueue", DISPATCH_QUEUE_SERIAL);
++  });
++  return queue;
++}
++
 +static NSError* ExtensionLaunchError(NSString* description,
 +                                     NSError* _Nullable underlying = nil) {
 +  NSDictionary* userInfo = underlying
@@ -127,7 +137,7 @@ index 000000000000..bd49425f027c
 +  dispatch_async(ExtensionLaunchQueue(), ^{
 +    __block bool completed = false;
 +    void (^completeOnce)(NSError* _Nullable) = ^(NSError* _Nullable error) {
-+      dispatch_async(ExtensionLaunchQueue(), ^{
++      dispatch_async(ExtensionCompletionQueue(), ^{
 +        if (completed) {
 +          return;
 +        }


### PR DESCRIPTION
## Summary

Avoid delaying completed NSExtension process launches behind subsequent extension creation work.

`ExtensionLaunchQueue` is intentionally serial because `NSExtension` request creation should remain serialized. However, `completeOnce` was also dispatched back onto that same queue. If another `beginExtensionRequestWithInputItems` call had already started, a child process that had successfully connected and sent its bootstrap ping could remain blocked waiting for the launch queue to become available.

This change adds a separate serial `ExtensionCompletionQueue` and dispatches only completion handling to it.

## Why

During startup tracing, a child process could finish its NSXPC bootstrap while `ExtensionLaunchQueue` was already occupied creating the next NSExtension request.

In that case, completion of the already-running child was delayed by roughly the duration of the following extension launch. With completion handling separated, the bootstrap ping can resolve the process launch immediately even while another request is being created.

The expensive `NSExtension` operations themselves remain serialized.

## Implementation

* Keep `NSExtension extensionWithIdentifier:` on `ExtensionLaunchQueue`.
* Keep `beginExtensionRequestWithInputItems:` on `ExtensionLaunchQueue`.
* Keep the launch timeout on `ExtensionLaunchQueue`.
* Add a separate serial `ExtensionCompletionQueue`.
* Dispatch `completeOnce` through the completion queue instead of the launch queue.

The completion queue is also serial, preserving the existing single-threaded access to the `completed` guard.

No concurrent NSExtension request creation is introduced.

## Validation

Startup diagnostics confirmed that after this change, completion processing occurs essentially immediately after the child bootstrap ping, including while `ExtensionLaunchQueue` is occupied by another process launch.

This removes queue-induced completion latency without changing the serialization of Apple NSExtension launch operations.
