### PR TITLE
Limit Fission preallocation to one process on iOS

### DIFF
--- a/patches/mobile/ios/app/mobile.js.patch
+++ b/patches/mobile/ios/app/mobile.js.patch
@@ -2,7 +2,7 @@ diff --git a/mobile/ios/app/mobile.js b/mobile/ios/app/mobile.js
 index e835b1c33d86..4c0bff531c6a 100644
 --- a/mobile/ios/app/mobile.js
 +++ b/mobile/ios/app/mobile.js
-@@ -3,7 +3,102 @@
+@@ -3,7 +3,103 @@
  // License, v. 2.0. If a copy of the MPL was not distributed with this
  // file, You can obtain one at http://mozilla.org/MPL/2.0/.
  
@@ -15,6 +15,7 @@ index e835b1c33d86..4c0bff531c6a 100644
 +
 +// Enable prelaunching of content processes.
 +pref("dom.ipc.processPrelaunch.enabled", true);
++pref("dom.ipc.processPrelaunch.fission.number", 1);
 +
 +pref("dom.ipc.processCount.webIsolated", 1);
 +
@@ -106,7 +107,7 @@ index e835b1c33d86..4c0bff531c6a 100644
  
  // Use software webrender on simulator due to missing APIs.
  #if TARGET_OS_SIMULATOR
-@@ -19,3 +114,5 @@ pref("security.sandbox.content.level", 1);
+@@ -19,3 +115,5 @@ pref("security.sandbox.content.level", 1);
  // 1 complete progressbar at DOMContentLoaded
  // 2 complete progressbar at first MozAfterPaint after DOMContentLoaded
  pref("page_load.progressbar_completion", 2);


### PR DESCRIPTION
## Summary

Limit the Fission preallocated content-process pool to one process on iOS.

Reynard currently enables content-process prelaunching but leaves Firefox's Fission preallocation count at its default. On iOS, each content process is backed by an NSExtension launch, which is relatively expensive and serialized. Filling a larger speculative pool during startup can therefore delay creation of the site-isolated process needed by the active tab.

This change keeps process prelaunching enabled, but sets:

```js
pref("dom.ipc.processPrelaunch.fission.number", 1);
```

## Why

Startup tracing showed that with the default pool size, Gecko began launching multiple speculative `remoteType=prealloc` processes after the initial frame. These launches occupied the serialized NSExtension launch path before the startup-critical `webIsolated` process for the restored tab was ready.

With the pool limited to one, Gecko still retains a warm spare process, but avoids filling several speculative slots during the critical startup window.

In an apples-to-apples cold-start test with the same restored ChatGPT tab selected:

* substantial first-tab presentation improved from about **8.5 s** to about **5.0 s**
* the `webIsolated=https://chatgpt.com` process started at about **4.1 s**
* the first large ChatGPT surface update reached Core Animation at about **4.94 s**
* the next speculative preallocation was not requested until after useful page rendering was already underway

This is roughly a **3.5 s / 41% reduction** in time to substantial first-tab content in that test.

## Scope

This does not disable process prelaunching or Fission. It only reduces the target number of preallocated Fission content processes from the default to one for Reynard's iOS configuration.
